### PR TITLE
Node Contributors List [OSF-7458]

### DIFF
--- a/swagger-spec/nodes/contributor_definition.yaml
+++ b/swagger-spec/nodes/contributor_definition.yaml
@@ -1,0 +1,78 @@
+type: object
+title: Contributor
+required:
+  - type
+  - relationships
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The identifier of the contributor entity. Contributor identifiers have the form {node_id}-{user_id}.'
+  type:
+    type: string
+    readOnly: true
+    description: 'The type identifier of the contributor entity (`contributors`).'
+  attributes:
+    type: object
+    readOnly: false
+    description: 'The properties of the contributor entity.'
+    properties:
+      bibliographic:
+        type: boolean
+        readOnly: false
+        description: 'Whether or not the contributor will be included in citations for the node. The default value is true.'
+      index:
+        type: integer
+        readOnly: false
+        description: 'The position of this contributor in the list of project contributors and in project citations.'
+      permission:
+        type: string
+        enum:
+          - read
+          - write
+          - admin
+        readOnly: false
+        description: 'The permission level of the contributor. The default value is ''write''.'
+      unregistered_contributor:
+        type: string
+        readOnly: true
+        description: 'The assigned name of the contributor if the contributor has not yet claimed their account.'
+  embeds:
+    type: string
+    readOnly: true
+    description: 'The full representation of the user this contributor '
+  relationships:
+    type: object
+    readOnly: false
+    description: 'URLs to other entities or entity collections that have a relationship to the contributor entity.'
+    required:
+      - node
+      - user
+    properties:
+      node:
+        type: string
+        readOnly: true
+        description: 'A relationship to the node that was created for the preprint, or from which the preprint was created.'
+      user:
+        type: string
+        readOnly: false
+        description: 'A relationship to the file that is designated as the preprint''s primary file, or the manuscript of the preprint.'
+  links:
+    type: object
+    readOnly: true
+    description: 'URLs to alternative representations of the contributor entity.'
+    properties:
+      self:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'A link to the the canonical API endpoint for the contributor.'
+example:
+  data:
+    type: contributors
+    attributes: {}
+    relationships:
+      user:
+        data:
+          type: users
+          id: '{user_id}'

--- a/swagger-spec/nodes/contributors_list.yaml
+++ b/swagger-spec/nodes/contributors_list.yaml
@@ -1,1 +1,166 @@
-# /nodes/{node_id}/contributors/
+parameters:
+- in: path
+  type: string
+  name: node_id
+  required: true
+  description: 'The unique identifier of the node.'
+
+get:
+  summary: List all contributors
+  description: >-
+    A paginated list of the node's contributors, sorted by their index.
+
+
+    Contributors are users who can make changes to the node or, in the case of private nodes, have read access to the node.
+
+
+    Contributors are categorized as either "bibliographic" or "non-bibliographic" contributors.
+    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+
+
+    Note that if an anonymous view_only key is being used to view the list of contributors, the user relationship will not be exposed and the contributor ID will be an empty string.
+
+
+    #### Returns
+
+    A JSON object with `data` and `links` keys.
+
+
+    The `data` key contains an array of 10 contributors.
+
+
+    Each resource in the array contains the full representation of the contributor, meaning additional requests to a contributor's detail view are not necessary.
+
+
+    Additionally, the full representation of the user this contributor represents is automatically embedded within the `data` key of the response.
+
+
+    The `links` key contains a dictionary of links that can be used for [pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
+
+    #### Filtering
+
+    You can optionally request that the response only include contributors that match your filters by utilizing the `filter` query parameter, e.g.
+    https://api.osf.io/v2/nodes/y9jdt/contributors/?filter[bibliographic]=true.
+
+
+    Contributors may be filtered by their `bibliographic` and `permission` attributes.
+
+  tags:
+    - Nodes
+  operationId: nodes_contributors_list
+  x-response-schema: Contributor
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        type: array
+        items:
+          $ref: contributor_definition.yaml
+      examples:
+        application/json:
+          data:
+          - relationships:
+              node:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/nodes/y9jdt/
+                    meta: {}
+              users:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/users/typ46/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/nodes/y9jdt/contributors/typ46/
+            embeds:
+              users:
+                data:
+                  relationships:
+                    nodes:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/typ46/nodes/
+                          meta: {}
+                    institutions:
+                      links:
+                        self:
+                          href: https://api.osf.io/v2/users/typ46/relationships/institutions/
+                          meta: {}
+                        related:
+                          href: https://api.osf.io/v2/users/typ46/institutions/
+                          meta: {}
+                  links:
+                    self: https://api.osf.io/v2/users/typ46/
+                    html: https://osf.io/typ46/
+                    profile_image: https://secure.gravatar.com/avatar/3dd8757ba100b8406413706886243811?d=identicon
+                  attributes:
+                    family_name: Geiger
+                    suffix: ''
+                    locale: en_us
+                    date_registered: '2014-03-18T19:11:57.252000'
+                    middle_names: J.
+                    given_name: Brian
+                    full_name: Brian J. Geiger
+                    active: true
+                    timezone: America/New_York
+                  type: users
+                  id: typ46
+            attributes:
+              index: 0
+              unregistered_contributor:
+              bibliographic: true
+              permission: admin
+            type: contributors
+            id: y9jdt-typ46
+          links:
+            first:
+            last:
+            prev:
+            next:
+            meta:
+              total: 9
+              per_page: 10
+              total_bibliographic: 1
+
+post:
+  summary: Create a contributor
+  description: >-
+    Adds a contributor to a node, effectively creating a relationship between the node and a user.
+
+
+    Contributors are users who can make changes to the node or, in the case of private nodes, have read access to the node.
+
+
+    Contributors are categorized as either "bibliographic" or "non-bibliographic" contributors.
+    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+
+    #### Required
+
+    A relationship object with a `data` key, containing the `users` type and valid user ID is required.
+
+
+    All attributes describing the relationship between the node and the user are optional.
+
+    #### Returns
+
+    Returns a JSON object with a `data` key containing the representation of the new contributor, if the request is successful.
+
+
+    If the request is unsuccessful, a dictionary with an `errors` property containing information about the failure will be returned.
+    Refer to the [list of error codes]() to understand why this request may have failed.
+
+  parameters:
+    - in: body
+      name: body
+      required: true
+      schema:
+        $ref: contributor_definition.yaml
+  tags:
+    - Nodes
+  operationId: nodes_contributors_create
+  x-response-schema: Contributor
+  consumes:
+    - application/json
+  responses:
+    '201':
+      description: 'Success'

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -168,6 +168,9 @@ paths:
   /nodes/{node_id}/citation/{style_id}/:
     $ref: 'nodes/styled_citation_detail.yaml'
 
+  /nodes/{node_id}/contributors/:
+    $ref: 'nodes/contributors_list.yaml'
+
   /nodes/{node_id}/forks/:
     $ref: 'nodes/forks_list.yaml'
 


### PR DESCRIPTION
- Documents `/nodes/{node_id}/contributors/` (contributor_list.yaml)
- Adds node contributor definition.
