### PR TITLE
Add arrow toggle to sample objects and responses

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -2473,10 +2473,13 @@ body {
     float:left;
     margin-left: -15px;
     padding-top: 10px;
-    padding-right: 5px;
     color: lightblue;
 }
 
 .glyphicon-link:hover {
     color: #44c7f4;
+}
+
+.glyphicon {
+    padding-right: 5px;
 }

--- a/src/main/javascript/view/SignatureView.js
+++ b/src/main/javascript/view/SignatureView.js
@@ -2,7 +2,9 @@
 
 SwaggerUi.Views.SignatureView = Backbone.View.extend({
   events: {
-    'mousedown .snippet': 'snippetToTextArea'
+    'mousedown .snippet': 'snippetToTextArea',
+    'click  h4.sample-title': 'toggleIcon',
+    'click  h4.schema-title': 'toggleIcon'
   },
 
   initialize: function () {
@@ -29,6 +31,17 @@ SwaggerUi.Views.SignatureView = Backbone.View.extend({
             this.model.jsonEditor.setValue(JSON.parse(this.model.sampleJSON));
          }
       }
+    }
+  },
+
+  // handler for changing arrow icon
+  toggleIcon: function (e) {
+    var iconId = e.currentTarget.attributes['data-toggle'].ownerElement.children[0];
+
+    if ($(iconId).hasClass('glyphicon-menu-right')) {
+      $(iconId).removeClass("glyphicon-menu-right").addClass("glyphicon-menu-down");
+    } else {
+      $(iconId).removeClass("glyphicon-menu-down").addClass("glyphicon glyphicon-menu-right");
     }
   }
 });

--- a/src/main/template/signature.handlebars
+++ b/src/main/template/signature.handlebars
@@ -1,6 +1,8 @@
 {{#if signature}}
-    <h4 class="schema-title collapsed" data-control data-toggle="collapse"
-        data-target="#schema-{{id}}">{{schemaName}} Object</h4>
+    <h4 class="schema-title collapsed" data-control data-toggle="collapse" data-target="#schema-{{id}}">
+        <span class="glyphicon glyphicon-menu-right"></span>
+        {{schemaName}} Object
+    </h4>
     <div data-content class="collapse" id="schema-{{id}}">
         <div class="description">
             {{{signature}}}
@@ -8,8 +10,10 @@
     </div>
 {{/if}}
 
-<h4 class="sample-title collapsed" data-control data-toggle="collapse"
-    data-target="#sample-{{id}}">Example {{type}}</h4>
+<h4 class="sample-title collapsed" data-control data-toggle="collapse" data-target="#sample-{{id}}">
+    <span class="glyphicon glyphicon-menu-right"></span>
+    Example {{type}}
+</h4>
 <div data-content class="collapse" id="sample-{{id}}">
     <div class="snippet">
         <pre><code>{{sampleJSON}}</code></pre>


### PR DESCRIPTION
## Changes
- Add arrow icons next to object and example response
- `toggleIcon` function that is fired when the heading is clicked

A GIF is worth a thousand words:

![toggle_arrows](https://cloud.githubusercontent.com/assets/801594/23182749/a8f432c6-f847-11e6-9f21-7d3309869663.gif)

## Ticket
https://openscience.atlassian.net/browse/OSF-7475
