### PR TITLE
Add Permissions Info to Nodes [OSF-7538]

### DIFF
--- a/swagger-spec/nodes/children_list.yaml
+++ b/swagger-spec/nodes/children_list.yaml
@@ -207,6 +207,10 @@ post:
     Note: Creating a child node via this endpoint will function the same as creating a node via the node list endpoint,
     but the child node will have the given node set as its parent.
 
+    #### Permissions
+
+    Only write contributors may create children nodes.
+
     #### Required
 
     Required fields for creating a node include:

--- a/swagger-spec/nodes/contributor_detail.yaml
+++ b/swagger-spec/nodes/contributor_detail.yaml
@@ -7,7 +7,7 @@ get:
     Contributors are users who can make changes to the node or, in the case of private nodes, have read access to the node.
 
 
-    Contributors are categorized as either "bibliographic" or "non-bibliographic" contributors.
+    Contributors are categorized as either "bibliographic" or "non-bibliographic".
     From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
 
     #### Returns
@@ -109,6 +109,10 @@ patch:
     Contributors can be updated with either a **PUT** or **PATCH** request.
     Since this endpoint has no mandatory attributes, PUT and PATCH are functionally the same.
 
+    #### Permissions
+
+    Only project administrators can update the contributors on a node.
+
     #### Returns
 
     Returns a dictionary with a `data` property containing the new representation of the updated
@@ -156,11 +160,11 @@ delete:
     This request only removes the relationship between the node and the user, it does not delete the user itself.
 
 
-    Only project administrators have permission to remove project contributors.
+    A node must always have at least one admin, and attempting to remove the only admin from a node will result in a **400 Bad Request** response.
 
+    #### Permissions
 
-    A node must always have at least one admin, and attempting to remove the only admin from a node will result in a 400 Bad Request response.
-
+    A user can remove themselves as a node contributor. Otherwise, only project administrators can remove contributors.
 
     #### Returns
 

--- a/swagger-spec/nodes/contributors_list.yaml
+++ b/swagger-spec/nodes/contributors_list.yaml
@@ -7,7 +7,7 @@ get:
     Contributors are users who can make changes to the node or, in the case of private nodes, have read access to the node.
 
 
-    Contributors are categorized as either "bibliographic" or "non-bibliographic" contributors.
+    Contributors are categorized as either "bibliographic" or "non-bibliographic".
     From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
 
 
@@ -132,6 +132,10 @@ post:
 
     Contributors are categorized as either "bibliographic" or "non-bibliographic" contributors.
     From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+
+    #### Permissions
+
+    Only project administrators can add contributors to a node.
 
     #### Required
 

--- a/swagger-spec/nodes/detail.yaml
+++ b/swagger-spec/nodes/detail.yaml
@@ -3,9 +3,10 @@ get:
   description: >-
     Retrieves the details of a given node (project or component).
 
+    #### Permissions
 
-    Only project contributors have permission to retrieve the details of a private node.
-    Attempting to retreive a node for which you are not a contributor will result in a **403 Forbidden** response.
+    Only project contributors may retrieve the details of a private node.
+    Attempting to retreive a private node for which you are not a contributor will result in a **403 Forbidden** response.
 
 
     Authentication is not required to view the details of a public node, as public nodes give read-only access to everyone.
@@ -168,6 +169,11 @@ patch:
     Nodes can be updated with either a **PUT** or **PATCH** request.
     The `title` and `category` fields are mandatory in a **PUT** request, and optional in a **PATCH**.
 
+    #### Permissions
+
+    Only write contributors may update a node.
+    Attempting to update a node for which you do not have write access will result in a **403 Forbidden** response.
+
     #### Returns
 
     Returns a dictionary with a `data` property containing the new representation of the updated
@@ -216,10 +222,10 @@ delete:
 
     Permanently deletes a node. This action cannot be undone.
 
+    #### Permissions
 
-    Only project administrators have permission to delete a node.
+    Only project administrators may delete a node.
     Attempting to delete a node for which you are not an administrator will result in a **403 Forbidden** response.
-
 
     #### Returns
 

--- a/swagger-spec/nodes/draft_registration_detail.yaml
+++ b/swagger-spec/nodes/draft_registration_detail.yaml
@@ -11,7 +11,7 @@ get:
 
     #### Permissions
 
-    A user must have admin permission on a node in order to view draft registrations.
+    Only project administrators may view draft registrations.
 
     #### Returns
 
@@ -103,7 +103,7 @@ patch:
 
     #### Permissions
 
-    A user must have admin permission on a node in order to update draft registrations.
+    Only project administrators may update draft registrations.
 
     #### Returns
 
@@ -149,7 +149,7 @@ delete:
 
     #### Permissions
 
-    A user must have admin permission on a node in order to delete draft registrations.
+    Only project administrators may delete draft registrations.
 
     #### Returns
 

--- a/swagger-spec/nodes/draft_registrations_list.yaml
+++ b/swagger-spec/nodes/draft_registrations_list.yaml
@@ -12,7 +12,7 @@ get:
 
     #### Permissions
 
-    Users must have admin permission on the node in order to view draft registrations.
+    Only project administrators may view draft registrations.
 
     #### Returns
 
@@ -94,7 +94,7 @@ post:
 
     #### Permissions
 
-    Users must have admin permission on the node in order to create draft registrations.
+    Only project administrators may view create registrations.
 
     #### Required
 

--- a/swagger-spec/nodes/preprints_list.yaml
+++ b/swagger-spec/nodes/preprints_list.yaml
@@ -1,13 +1,12 @@
 get:
   summary: List all preprints
   description: >-
-
-    **Note: This API endpoint is under active development, and is subject to change in the future.**
-
-
     A paginated list of preprints related to a given node.
     The returned preprints are sorted by their creation date, with the most recent
     preprints appearing first.
+
+
+    **Note: This API endpoint is under active development, and is subject to change in the future.**
 
     #### Returns
 


### PR DESCRIPTION
- Adds `permissions` section to node endpoint descriptions.