### PR TITLE
Add ability to copy URLs automatically by clicking icon!

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,8 +56,9 @@ gulp.task('dist', ['clean'], function() {
 
   return es.merge(
       gulp.src([
-        './src/main/javascript/**/*.js',
-        './node_modules/swagger-client/browser/swagger-client.js'
+          './src/main/javascript/**/*.js',
+          './node_modules/swagger-client/browser/swagger-client.js',
+          './node_modules/clipboard/dist/clipboard.min.js'
       ]),
       templates()
     )

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "swagger-ui",
   "author": "Tony Tam <fehguy@gmail.com>",
-  "contributors": [{
-    "name": "Mohsen Azimi",
-    "email": "me@azimi.me"
-  },
-  {
-    "name": "Fares Droubi",
-    "email": "fares.droubi@gmail.com"
-  }],
+  "contributors": [
+    {
+      "name": "Mohsen Azimi",
+      "email": "me@azimi.me"
+    },
+    {
+      "name": "Fares Droubi",
+      "email": "fares.droubi@gmail.com"
+    }
+  ],
   "description": "Swagger UI is a dependency-free collection of HTML, JavaScript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API",
   "version": "2.1.1-M2",
   "homepage": "http://swagger.io",
@@ -51,5 +53,8 @@
     "mocha": "^2.1.0",
     "selenium-webdriver": "^2.45.0",
     "swagger-client": "git+https://github.com/jensoleg/swagger-js.git"
+  },
+  "dependencies": {
+    "clipboard": "^1.6.0"
   }
 }

--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -2469,17 +2469,17 @@ body {
     padding-top: 10px
 }
 
-.glyphicon-link {
-    float:left;
-    margin-left: -15px;
-    padding-top: 10px;
-    color: lightblue;
-}
-
 .glyphicon-link:hover {
     color: #44c7f4;
 }
 
 .glyphicon {
     padding-right: 5px;
+}
+
+.anchor-link {
+    float:left;
+    margin-left: -15px;
+    padding-top: 10px;
+    color: lightblue;
 }

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -86,6 +86,28 @@
 
                     $("[data-toggle='tooltip']").tooltip();
 
+                    // Add ability to copy links and display tooltip if supported
+                    if (Clipboard.isSupported()) {
+                        $('.anchor-link').tooltip({
+                            delay: 500,
+                            title: 'Copy URL to clipboard',
+                            placement: 'left'
+                        });
+
+                        new Clipboard('.anchor-link', {
+                            text: function(trigger) {
+                                return $(trigger).get(0).href;
+                            }
+                        }).on('success', function(e) {
+                            $(e.trigger).attr('title', 'Copied!')
+                            .tooltip('fixTitle')
+                            .tooltip('show');
+
+                            $(e.trigger).attr('title', 'Copy URL to clipboard')
+                            .tooltip('fixTitle');
+                        });
+                    }
+
                     // addApiKeyAuthorization();
                 },
                 onFailure: function (data) {

--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -230,7 +230,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
   updateHashOnScroll: function(e) {
     var currentHash = '#';
     var padding = 20;
-    $('.anchor_link').each(function () {
+    $('.anchor-link').each(function () {
         var top = window.pageYOffset;
         var distance = top - $(this).offset().top;
         var hash = $(this).attr('href');

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -3,7 +3,7 @@
         <div class='content'>
             <div class='heading'>
                 <div>
-                    <a href='#{{parentId}}_{{nickname}}' class="anchor_link">
+                    <a href='#{{parentId}}_{{nickname}}' class="anchor-link">
                         <span class="glyphicon glyphicon-link"></span>
                     </a>
                     <h2 class='operation-title'>{{summary}}</h2>


### PR DESCRIPTION
## Changes

Hover over a link icon, it will tell you that clicking it will copy to your clipboard! And it will!

[If your browser supports it](https://clipboardjs.com/#browser-support) (most do):
- Add copy listener to `anchor-link` 
- Add tooltip explaining and then update when copied
- Change tooltip back when done

Other changes:
- Add clipboard js to package.json (silly pycharm reformatting dumb stuff grrrrrr)
- install from npm when running gulp
- rename to `anchor-link` to be more javascripty
- use the CSS on the outer link so the tooltip follows it too!

## How it looks:

![copy_url](https://cloud.githubusercontent.com/assets/801594/23221186/620de130-f8f2-11e6-87ba-26c445a6b818.gif)
