### PR TITLE
API Authorization for PUT, POST, and PATCH requests

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -2474,3 +2474,45 @@ body {
     padding-top: 10px;
     color: lightblue;
 }
+
+.auth-container {
+    margin: 20px 20px 20px;
+}
+
+.auth_input {
+    margin-top: 6px;
+    padding-top: 6px;
+    padding-bottom: 7px;
+    padding-left: 12px;
+    font-family: inherit;
+
+}
+
+.token-indicator {
+    font-size: smaller;
+    margin-top: 5px;
+    font-style: italic;
+    font-family: inherit;
+}
+
+.osf-token-info {
+    font-size: smaller;
+    margin-top: 5px;
+    font-style: italic;
+    font-family: inherit;
+}
+
+.try-hide {
+    font-family: inherit;
+    font-size: inherit;
+    font-color: inherit;
+}
+
+.put-post-patch-info {
+    background-color: #d9edf7;
+}
+
+#clear-token-link {
+    padding-left: 57px;
+    cursor: pointer;
+}

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -108,7 +108,6 @@
                         });
                     }
 
-                    // addApiKeyAuthorization();
                 },
                 onFailure: function (data) {
                     log("Unable to Load SwaggerUI");
@@ -116,23 +115,6 @@
                 docExpansion: "none",
                 sorter: "alpha"
             });
-
-            // function addApiKeyAuthorization() {
-            //     var key = encodeURIComponent($('#input_apiKey')[0].value);
-            //     if (key && key.trim() != "") {
-            //         var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + key, "header");
-            //         window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
-            //         log("added key " + key);
-            //     }
-            // }
-
-            // $('#input_apiKey').change(addApiKeyAuthorization);
-            // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
-            /*
-             var apiKey = "myApiKeyXXXX123456789";
-             $('#input_apiKey').val(apiKey);
-             */
-
             window.swaggerUi.load();
 
             function log() {

--- a/src/main/javascript/helpers/handlebars.js
+++ b/src/main/javascript/helpers/handlebars.js
@@ -5,3 +5,11 @@ Handlebars.registerHelper('sanitize', function(html) {
     html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
     return new Handlebars.SafeString(html);
 });
+
+Handlebars.registerHelper('notequal', function(value1, value2, options) {
+    if (value1 == value2) {
+        return options.inverse(this);
+    } else {
+        return options.fn(this);
+    }
+});

--- a/src/main/javascript/view/ApiKeyButton.js
+++ b/src/main/javascript/view/ApiKeyButton.js
@@ -4,7 +4,8 @@ SwaggerUi.Views.ApiKeyButton = Backbone.View.extend({ // TODO: append this to gl
 
   events:{
     'click #apikey_button' : 'toggleApiKeyContainer',
-    'click #apply_api_key' : 'applyApiKey'
+    'click #apply_api_key' : 'applyApiKey',
+    'click #clear-token-link': 'removeApiKey'
   },
 
   initialize: function(opts){
@@ -15,19 +16,21 @@ SwaggerUi.Views.ApiKeyButton = Backbone.View.extend({ // TODO: append this to gl
   render: function(){
     var template = this.template();
     $(this.el).html(template(this.model));
-
     return this;
   },
 
-
   applyApiKey: function(){
-    var keyAuth = new SwaggerClient.ApiKeyAuthorization(
-      this.model.name,
-      $('#input_apiKey_entry').val(),
-      this.model.in
-    );
-    this.router.api.clientAuthorizations.add(this.model.name, keyAuth);
-    this.router.load();
+    var key = encodeURIComponent($('#input_apiKey_entry')[0].value);
+    if (key && key.trim() != "") {
+      var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + key, "header");
+      this.router.api.clientAuthorizations.add("key", apiKeyAuth);
+      $('.token-indicator').removeClass("hidden");
+      $('.osf-token-info').addClass("hidden");
+      $('.put-post-patch-try').removeClass("hidden");
+      $('.put-post-patch-info').addClass("hidden");
+    } else {
+      this.removeApiKey();
+    }
     $('#apikey_container').show();
   },
 
@@ -35,10 +38,14 @@ SwaggerUi.Views.ApiKeyButton = Backbone.View.extend({ // TODO: append this to gl
     if ($('#apikey_container').length) {
 
       var elem = $('#apikey_container').first();
+      var button = $('#apikey_menu_icon');
 
       if (elem.is(':visible')){
         elem.hide();
+        button.removeClass("glyphicon-menu-down").addClass("glyphicon glyphicon-menu-right");
+
       } else {
+        button.removeClass("glyphicon-menu-right").addClass("glyphicon-menu-down");
 
         // hide others
         $('.auth_container').hide();
@@ -49,6 +56,15 @@ SwaggerUi.Views.ApiKeyButton = Backbone.View.extend({ // TODO: append this to gl
 
   template: function(){
     return Handlebars.templates.apikey_button_view;
+  },
+
+  removeApiKey: function() {
+    this.router.api.clientAuthorizations.remove("key");
+    $('#input_apiKey_entry')[0].value = '';
+    $('.token-indicator').addClass("hidden");
+    $('.osf-token-info').removeClass("hidden");
+    $('.put-post-patch-try').addClass("hidden");
+    $('.put-post-patch-info').removeClass("hidden");
   }
 
 });

--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -100,23 +100,6 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
   },
 
   render: function () {
-    if (this.model.securityDefinitions) {
-      for (var name in this.model.securityDefinitions) {
-        var auth = this.model.securityDefinitions[name];
-        var button;
-
-        if (auth.type === 'apiKey' && $('#apikey_button').length === 0) {
-          button = new SwaggerUi.Views.ApiKeyButton({model: auth, router: this.router}).render().el;
-          $('.auth_main_container').append(button);
-        }
-
-        if (auth.type === 'basicAuth' && $('#basic_auth_button').length === 0) {
-          button = new SwaggerUi.Views.BasicAuthButton({model: auth, router: this.router}).render().el;
-          $('.auth_main_container').append(button);
-        }
-      }
-    }
-
     // Render the outer container for resources
     $(this.el).html(Handlebars.templates.main(this.model));
 
@@ -150,6 +133,23 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       var n = $(this.el).find("#resources_nav [data-resource]").first();
       n.trigger("click");
       $(window).scrollTop(0)
+    }
+
+    if (this.model.securityDefinitions) {
+      for (var name in this.model.securityDefinitions) {
+        var auth = this.model.securityDefinitions[name];
+        var button;
+
+        if (auth.type === 'apiKey' && $('#apikey_button').length === 0) {
+          button = new SwaggerUi.Views.ApiKeyButton({model: auth, router: this.router}).render().el;
+          $('.auth_main_container').append(button);
+        }
+
+        if (auth.type === 'basicAuth' && $('#basic_auth_button').length === 0) {
+          button = new SwaggerUi.Views.BasicAuthButton({model: auth, router: this.router}).render().el;
+          $('.auth_main_container').append(button);
+        }
+      }
     }
 
     return this;
@@ -243,32 +243,32 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
 
   },
 
-  // toggleToken: function (e) {
-  //   var t = $(".token-generator"),
-  //     tg = $("[data-tg-switch]");
+  toggleToken: function (e) {
+    var t = $(".token-generator"),
+      tg = $("[data-tg-switch]");
 
-  //   t.toggleClass("hide");
-  //   t.hasClass("hide") ? tg.removeClass("active") : tg.addClass("active");
-  //   t.parents(".sticky-nav").trigger("mobile_nav:update")
-  // },
+    t.toggleClass("hide");
+    t.hasClass("hide") ? tg.removeClass("active") : tg.addClass("active");
+    t.parents(".sticky-nav").trigger("mobile_nav:update")
+  },
 
-  // closeToken: function (e) {
-  //   var t = $(".token-generator"),
-  //     tg = $("[data-tg-switch]");
+  closeToken: function (e) {
+    var t = $(".token-generator"),
+      tg = $("[data-tg-switch]");
 
-  //   t.addClass("hide");
-  //   tg.removeClass("active");
-  //   t.parents(".sticky-nav").trigger("mobile_nav:update")
-  // },
+    t.addClass("hide");
+    tg.removeClass("active");
+    t.parents(".sticky-nav").trigger("mobile_nav:update")
+  },
 
-  // openToken: function (e) {
-  //   var t = $(".token-generator"),
-  //     tg = $("[data-tg-switch]");
+  openToken: function (e) {
+    var t = $(".token-generator"),
+      tg = $("[data-tg-switch]");
 
-  //   t.removeClass("hide");
-  //   tg.removeClass("active");
-  //   t.parents(".sticky-nav").trigger("mobile_nav:update")
-  // },
+    t.removeClass("hide");
+    tg.removeClass("active");
+    t.parents(".sticky-nav").trigger("mobile_nav:update")
+  },
 
   showCustom: function(e){
     if (e) {

--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -137,6 +137,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
 
       this.addResource(resource, this.model.auths);
       this.addSidebarHeader(resource, i);
+      this.addSidebarToken(resource, i);
     }
 
     $('.propWrap').hover(function onHover() {
@@ -173,23 +174,23 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
     $('#resources').append(resourceView.render().el);
   },
 
-  // addSidebarToken: function (resource, i) {
-  //   resource.id = resource.id.replace(/\s/g, '_');
-  //   var sidebarView = new SwaggerUi.Views.SidebarHeaderView({
-  //     model: resource,
-  //     tagName: 'div',
-  //     className: function () {
-  //       return i == 0 ? 'active' : ''
-  //     },
-  //     attributes: {
-  //       "data-resource": 'resource_' + resource.name,
-  //       "label": resource.name
-  //     },
-  //     router: this.router,
-  //     swaggerOptions: this.options.swaggerOptions
-  //   });
-  //   $('#token-generator', $(this.el)).append(sidebarView.render().el);
-  // },
+  addSidebarToken: function (resource, i) {
+    resource.id = resource.id.replace(/\s/g, '_');
+    var sidebarView = new SwaggerUi.Views.SidebarHeaderView({
+      model: resource,
+      tagName: 'div',
+      className: function () {
+        return i == 0 ? 'active' : ''
+      },
+      attributes: {
+        "data-resource": 'resource_' + resource.name,
+        "label": resource.name
+      },
+      router: this.router,
+      swaggerOptions: this.options.swaggerOptions
+    });
+    $('#token-generator', $(this.el)).append(sidebarView.render().el);
+  },
 
 
   addSidebarHeader: function (resource, i) {
@@ -240,7 +241,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
         }
     });
 
-  }
+  },
 
   // toggleToken: function (e) {
   //   var t = $(".token-generator"),
@@ -269,13 +270,13 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
   //   t.parents(".sticky-nav").trigger("mobile_nav:update")
   // },
 
-  // showCustom: function(e){
-  //   if (e) {
-  //     e.preventDefault();
-  //   }
-  //   this.trigger('update-swagger-ui', {
-  //     url: $('#input_baseUrl').val(),
-  //     apiKey: $('#input_apiKey').val()
-  //   });
-  // }
+  showCustom: function(e){
+    if (e) {
+      e.preventDefault();
+    }
+    this.trigger('update-swagger-ui', {
+      url: $('#input_baseUrl').val(),
+      apiKey: $('#input_apiKey').val()
+    });
+  }
 });

--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -26,7 +26,6 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
     this.nickname = this.model.nickname;
     this.model.encodedParentId = encodeURIComponent(this.parentId);
     this.model.endpoint = api_topics.indexOf(this.model.summary) == -1 ? true : false;
-    this.model.read = this.model.method == 'get';
     this.schemaName = this.model.operation['x-response-schema'];
     return this;
   },

--- a/src/main/template/apikey_button_view.handlebars
+++ b/src/main/template/apikey_button_view.handlebars
@@ -1,11 +1,11 @@
 <div class='auth_button' id='apikey_button'>
-    <!--img class='auth_icon' alt='apply api key' src='images/apikey.jpeg'-->
+    <span id="apikey_menu_icon" class="glyphicon glyphicon-menu-down"></span>API Authorization
 </div>
 <div class='auth_container' id='apikey_container'>
   <div class='key_input_container'>
     <div class='auth_label'>{{keyName}}</div>
-    <input placeholder="api_key" class="auth_input" id="input_apiKey_entry" name="apiKey" type="text"/>
-    <div class='auth_submit'><a class='auth_submit_button' id="apply_api_key" href="#">apply</a></div>
+    <input placeholder="enter api token" class="auth_input" id="input_apiKey_entry" name="apiKey" type="password"/>
+    <button class='btn btn-default' id="apply_api_key"><span class="glyphicon glyphicon-arrow-right"></span></button>
   </div>
+    <div class="token-indicator hidden">Token updated<a id="clear-token-link">clear</a></div>
 </div>
-

--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -5,6 +5,13 @@
                 <a href="https://api.osf.io"><img src="images/osf-logo.png" width="27"/> OSF API</a>
             </div>
 
+            <div class="auth-container">
+                <div class="auth_main_container">
+                </div>
+                <div>
+                    <a class="osf-token-info" href="{{info.x-token-settings}}">Get an API Token</a>
+                </div>
+            </div>
             <div class="mobile-nav">
                 <span class="select-label">API Reference: </span><span data-selected-value></span>
             </div>

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -37,6 +37,13 @@
                 <div class="markdown action-summary">{{{description}}}</div>
             {{/if}}
 
+            {{#notequal this.method 'get'}}
+                <div class="swagger-section action-summary put-post-patch-info"><p>To enable the "try it out" feature for patch, post, or delete requests,
+                    <a href="#apikey_button">enter an OSF API Token at the top of the sidebar.</a></p>
+                </div>
+                <div class="put-post-patch-try hidden">
+            {{/notequal}}
+
             <form accept-charset="UTF-8" class="sandbox">
 
                 {{#if endpoint}}
@@ -58,8 +65,8 @@
                             <input class="submit btn btn-primary" name="commit" type="submit" value="try"
                                    data-target="#get_clients-modal-request">
                             <a href="#" class="response_hider hide" style="display: inline;">Hide Response</a>
-                            <!--small class="curl-copy-message hide" style="display:none;">Copied to clipboard</small-->
-                            <!--span class="response_throbber hide" style="display: none;"></span-->
+                            <small class="curl-copy-message hide" style="display:none;">Copied to clipboard</small>
+                            <span class="response_throbber hide" style="display: none;"></span>
 
                             {{#oauth}}
                             <div class="auth">
@@ -102,6 +109,11 @@
 
                 {{/if}}
             </form>
+
+            {{#notequal this.method 'get'}}
+            </div>
+            {{/notequal}}
+
         </div>
 
         <div class="samples">

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -40,48 +40,51 @@
             <form accept-charset="UTF-8" class="sandbox">
 
                 {{#if endpoint}}
-                    {{#if read}}
-                        {{#if parameters}}
-                            <h4 data-control data-parm-toggle data-toggle="collapse"
-                                data-target="#parm-{{parentId}}_{{nickname}}">
-                                Parameters
-                            </h4>
-                            <div data-content class="operation-params collapse in" id="parm-{{parentId}}_{{nickname}}"/>
-                        {{/if}}
 
-                        <div id="test-{{parentId}}_{{nickname}}">
-                            <div class="sandbox_header collapse in" data-content>
-                                <input class="submit btn btn-primary" name="commit" type="submit" value="try"
-                                       data-target="#get_clients-modal-request">
-                                <a href="#" class="response_hider hide" style="display: inline;">Hide Response</a>
-                                <!--small class="curl-copy-message hide" style="display:none;">Copied to clipboard</small-->
-                                <!--span class="response_throbber hide" style="display: none;"></span-->
+                    {{#if parameters}}
+                        <h4 data-control data-parm-toggle data-toggle="collapse"
+                            data-target="#parm-{{parentId}}_{{nickname}}">
+                            Parameters
+                        </h4>
+                        <div data-content class="operation-params collapse in" id="parm-{{parentId}}_{{nickname}}"/>
+                    {{/if}}
 
-                                {{#oauth}}
-                                <div class="auth">
-                                {{/oauth}}
+{{!--                     <h4 data-control data-toggle="collapse" data-target="#test-{{parentId}}_{{nickname}}">
+                        Test this endpoint
+                    </h4>
+ --}}
+                    <div id="test-{{parentId}}_{{nickname}}">
+                        <div class="sandbox_header collapse in" data-content>
+                            <input class="submit btn btn-primary" name="commit" type="submit" value="try"
+                                   data-target="#get_clients-modal-request">
+                            <a href="#" class="response_hider hide" style="display: inline;">Hide Response</a>
+                            <!--small class="curl-copy-message hide" style="display:none;">Copied to clipboard</small-->
+                            <!--span class="response_throbber hide" style="display: none;"></span-->
 
-                                {{#each oauth}}
-                                    <div id="api_information_panel" style="top: 526px; left: 776px; display: none;">
-                                        {{#each this}}
-                                            <div title='{{{this.description}}}'>{{this.scope}}</div>
-                                        {{/each}}
-                                    </div>
-                                {{/each}}
+                            {{#oauth}}
+                            <div class="auth">
+                            {{/oauth}}
 
-                                {{#oauth}}
-                                    <button type="button" class="api-ic ic-off btn btn-default pull-right">Oauth</button>
+                            {{#each oauth}}
+                                <div id="api_information_panel" style="top: 526px; left: 776px; display: none;">
+                                    {{#each this}}
+                                        <div title='{{{this.description}}}'>{{this.scope}}</div>
+                                    {{/each}}
                                 </div>
-                                {{/oauth}}
+                            {{/each}}
 
+                            {{#oauth}}
+                                <button type="button" class="api-ic ic-off btn btn-default pull-right">Oauth</button>
                             </div>
-
-                            {{#if type}}
-                                <div class="response-content-type"/>
-                            {{/if}}
+                            {{/oauth}}
 
                         </div>
-                    {{/if}}
+
+                        {{#if type}}
+                            <div class="response-content-type"/>
+                        {{/if}}
+
+                    </div>
 
 {{!--                     {{#if responseMessages}}
                         <div style="margin:0;padding:0;display:inline"></div>

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -10,12 +10,20 @@ info:
     name: OSF
     email: support@osf.io
     url: 'https://osf.io/support'
+  x-token-settings: 'https://test.osf.io/settings/tokens/'
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 host: 'test-api.osf.io'
 schemes:
-  - https
+  - http
+securityDefinitions:
+  api_key:
+    type: apiKey
+    in: header
+    name: api_key
+  basic:
+    type: basic
 basePath: /v2
 paths:
 


### PR DESCRIPTION
Add API token header auth for interactive use of the API!

![screen shot 2017-02-23 at 5 29 07 pm](https://cloud.githubusercontent.com/assets/801594/23282084/c1356146-f9ed-11e6-8202-6446afa54d5a.png)


- Update swagger.yaml to include API header auth
- Also include a link to where to set your token
- Template updates to show auth info where appropriate
- Clear and reset the token from the sidebar
- CSS and style updates
- helper function to compare the type of request and if you have a key
    or not

future improvements:
- simply disable the "TRY" button with no key, don't hide the form entirely
- add a note in the base route that the return value will change if you provide authorization