### PR TITLE
[feature] Add date_withdrawn to Registration Docs [OSF-5808]

### DIFF
--- a/swagger-spec/registrations/definition.yaml
+++ b/swagger-spec/registrations/definition.yaml
@@ -65,6 +65,11 @@ properties:
         format: date-time
         readOnly: true
         description: 'The time at which this registration was created, as an iso8601 formatted timestamp.'
+      date_withdrawn:
+        type: string
+        format: date-time
+        readOnly: true
+        description: 'The time at which this registration was withdrawn, as an iso8601 formatted timestamp.'
       description:
         type: string
         readOnly: true

--- a/swagger-spec/registrations/detail.yaml
+++ b/swagger-spec/registrations/detail.yaml
@@ -24,7 +24,7 @@ get:
 
     Registrations cannot be deleted, but they can be withdrawn.
     Withdrawing a registration removes the content of the registration but leaves behind basic metadata.
-    A withdrawn registration will display a limited subset of information, namely, title, description, date_created, registration, withdrawn, date_registered, withdrawal_justification, and registration supplement.
+    A withdrawn registration will display a limited subset of information, namely, title, description, date_created, date_registered, date_withdrawn, registration, withdrawn, withdrawal_justification, and registration supplement.
     All other fields will be displayed as null.
     Additionally, the only relationship that remains accesible for a withdrawn registration is the contributors.
     All other relationships will return a **403 Forbidden** response.

--- a/swagger-spec/registrations/list.yaml
+++ b/swagger-spec/registrations/list.yaml
@@ -23,7 +23,7 @@ get:
 
     Registrations cannot be deleted, but they can be withdrawn.
     Withdrawing a registration removes the content of the registration but leaves behind basic metadata.
-    A withdrawn registration will display a limited subset of information, namely, title, description, date_created, registration, withdrawn, date_registered, withdrawal_justification, and registration supplement.
+    A withdrawn registration will display a limited subset of information, namely, title, description, date_created, date_registered, date_withdrawn, registration, withdrawn, withdrawal_justification, and registration supplement.
     All other fields will be displayed as null.
     Additionally, the only relationship that remains accesible for a withdrawn registration is the contributors.
     All other relationships will return a **403 Forbidden** response.
@@ -103,6 +103,7 @@ get:
               date_modified: '2016-02-04T20:58:11.042000'
               date_registered: '2015-06-01T14:47:40.064000'
               date_created: '2015-05-21T19:38:55.398000'
+              date_withdrawn:
               pending_withdrawal: false
               node_license:
             relationships:


### PR DESCRIPTION
Documents the Registration `date_withdrawn` field. 

Depends on https://github.com/CenterForOpenScience/osf.io/pull/6898/files.

