### PR TITLE
[Feature] View Only Link documentation [OSF-7470]

### DIFF
--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -285,6 +285,13 @@ paths:
   /users/{user_id}/registrations/:
     $ref: 'users/registrations_list.yaml'
 
+  ######################
+  #   View Only Links  #
+  ######################
+
+  /view_only_links/{link_id}/:
+    $ref: 'view_only_links/detail.yaml'
+
   #############
   #   WIKIS   #
   #############

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -291,7 +291,9 @@ paths:
 
   /view_only_links/{link_id}/:
     $ref: 'view_only_links/detail.yaml'
-
+  /view_only_links/{link_id}/nodes/:
+    $ref: 'view_only_links/nodes.yaml'
+    
   #############
   #   WIKIS   #
   #############

--- a/swagger-spec/view_only_links/definition.yaml
+++ b/swagger-spec/view_only_links/definition.yaml
@@ -9,11 +9,11 @@ properties:
   id:
     type: string
     readOnly: true
-    description: 'The identifier of the view only link.'
+    description: 'The unique identifier of the view only link.'
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the view only link.'
+    description: "The type identifier of the view only link ('view-only-links')."
   attributes:
     type: object
     title: Attributes
@@ -24,14 +24,16 @@ properties:
         type: string
         format: date-time
         readOnly: true
-        description: 'The time at which the view only link was created'
+        description: 'The time at which the view only link was created, as an iso8601 formatted timestamp.'
       anonymous:
         type: boolean
-        readOnly: true
+        default: true
+        readOnly: false
         description: 'Whether or not the view only link has anonymized contributors'
       name:
         type: string
-        readOnly: true
+        default: 'Shared project link'
+        readOnly: false
         description: 'The name of the view only link'
       key:
         type: string
@@ -50,7 +52,7 @@ properties:
         type: string
         format: URL
         readOnly: false
-        description: 'A relationship to the nodes affiliated with this view only link.'
+        description: 'A relationship to the nodes which this view only link gives read-only access to.'
       creator:
         type: string
         readOnly: true

--- a/swagger-spec/view_only_links/definition.yaml
+++ b/swagger-spec/view_only_links/definition.yaml
@@ -1,0 +1,57 @@
+type: object
+title: view-only-links
+required:
+  - id
+  - type
+  - attributes
+  - relationships
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The identifier of the view only link.'
+  type:
+    type: string
+    readOnly: true
+    description: 'The type identifier of the view only link.'
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: true
+    description: 'The properties of the view only link entity.'
+    properties:
+      date_created:
+        type: string
+        format: date-time
+        readOnly: true
+        description: 'The time at which the view only link was created'
+      anonymous:
+        type: boolean
+        readOnly: true
+        description: 'Whether or not the view only link has anonymized contributors'
+      name:
+        type: string
+        readOnly: true
+        description: 'The name of the view only link'
+      key:
+        type: string
+        readOnly: true
+        description: 'The view only key'
+  relationships:
+    type: object
+    title: Relationships
+    readOnly: true
+    description: 'URLs to other entities or entity collections that have a relationship to the view only link entity.'
+    required:
+      - nodes
+      - creator
+    properties:
+      nodes:
+        type: string
+        format: URL
+        readOnly: false
+        description: 'A relationship to the nodes affiliated with this view only link.'
+      creator:
+        type: string
+        readOnly: true
+        description: 'A relationship to the user who created this view only link.'

--- a/swagger-spec/view_only_links/detail.yaml
+++ b/swagger-spec/view_only_links/detail.yaml
@@ -1,1 +1,59 @@
 # /view_only_links/{link_id}/
+get:
+  summary: Retrieve a view only link
+  description: >-
+        Retrieves details about a specific view only link.
+
+        ####Permissions
+
+        View only links on a node, public or private, are only readable and
+        writeable by users that are administrators on the node.
+
+        #### Returns
+
+        Returns a JSON object with a `data` key containing the representation of the requested
+        view only link, if the request is successful.
+
+        If the request is unsuccessful, an `errors` key containing
+        information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+        to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      name: link_id
+      required: true
+      description: 'The unique identifier of the view only link.'
+  tags:
+    - View Only Links
+  operationId: view_only_links_read
+  x-response-schema: 'View Only Link'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: definition.yaml
+      examples:
+        application/json:
+          data:
+            relationships:
+              nodes:
+                links:
+                  self:
+                    href: http://api.osf.io/v2/view_only_links/<link_id>/relationships/nodes/
+                    meta: {}
+                  related:
+                    href: http://api.osf.io/v2/view_only_links/<link_id>/nodes/
+                    meta: {}
+              creator:
+                links:
+                  related:
+                    href: http://api.osf.io/v2/users/<user_id>/
+                    meta: {}
+            attributes:
+              date_created: '2017-03-20T20:11:01.603851'
+              anonymous: false
+              key: <view_only_link_key>
+              name: Test View Only Link
+            type: view-only-links
+            id: <link_id>

--- a/swagger-spec/view_only_links/detail.yaml
+++ b/swagger-spec/view_only_links/detail.yaml
@@ -6,8 +6,8 @@ get:
 
         ####Permissions
 
-        View only links on a node, public or private, are only readable and
-        writeable by users that are administrators on the node.
+        Only project administrators may retrieve the details of a view only link.
+        Attempting to retrieve a view only link without appropriate permissions will result in a 403 Forbidden response.
 
         #### Returns
 

--- a/swagger-spec/view_only_links/nodes.yaml
+++ b/swagger-spec/view_only_links/nodes.yaml
@@ -6,33 +6,25 @@ get:
 
     #### Permissions
 
-    This requires admin permissions on all nodes to be associated with this view only link.
+    Only project administrators may retrieve the nodes of a view only link.
+    Attempting to retrieve a view only link without appropriate permissions will
+    result in a 403 Forbidden response.
 
     #### Returns
 
     Returns a JSON object containing `data` and `links` keys.
 
-    The `data` key contains an array of 10 nodes.
-    Each resource in the array is a separate node object and contains the full representation of the node, meaning additional requests to a node's detail view are not necessary.
+    The `data` key contains an array of up to 10 nodes.
+    Each resource in the array is a separate node object and contains the full
+    representation of the node, meaning additional requests to a node's detail
+    view are not necessary.
 
 
     The `links` key contains a dictionary of links that can be used for [pagination](#Introduction_pagination).
 
 
-    This request should never return an error.
-
-    #### Filtering
-
-    You can optionally request that the response only include nodes that match your filters by utilizing the `filter` query parameter, e.g.
-    https://api.osf.io/v2/nodes/?filter[title]=reproducibility.
-
-
-    Nodes may be filtered by their `id`, `title`, `category`, `description`, `public`, `tags`, `date_created`, `date_modified`, `root`, `parent`, `preprint`, and `contributors`.
-
-
-    Most fields are string fields and will be filtered using simple substring matching.
-    Public and preprint are boolean fields, and can be filtered using truthy values, such as **true**, **false**, **0** or **1**.
-    Note that quoting true or false in the query will cause the match to fail.
+    If the request is unsuccessful, an `errors` key containing information about the failure will be returned.
+    Refer to the [list of error codes](#Introduction_error_codes) to understand why this request may have failed.
 
   parameters:
     - in: path

--- a/swagger-spec/view_only_links/nodes.yaml
+++ b/swagger-spec/view_only_links/nodes.yaml
@@ -51,122 +51,370 @@ get:
                 files:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/files/
+                      href: https://api.osf.io/v2/nodes/bifc7/files/
                       meta: {}
                 view_only_links:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/view_only_links/
+                      href: https://api.osf.io/v2/nodes/bifc7/view_only_links/
                       meta: {}
                 citation:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/citation/
+                      href: https://api.osf.io/v2/nodes/bifc7/citation/
                       meta: {}
                 draft_registrations:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/draft_registrations/
+                      href: https://api.osf.io/v2/nodes/bifc7/draft_registrations/
                       meta: {}
                 contributors:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/contributors/
+                      href: https://api.osf.io/v2/nodes/bifc7/contributors/
                       meta: {}
                 forks:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/forks/
+                      href: https://api.osf.io/v2/nodes/bifc7/forks/
                       meta: {}
                 root:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/
+                      href: https://api.osf.io/v2/nodes/bifc7/
                       meta: {}
                 identifiers:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/identifiers/
+                      href: https://api.osf.io/v2/nodes/bifc7/identifiers/
                       meta: {}
                 comments:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/comments/?filter%5Btarget%5D=gaz5n
+                      href: https://api.osf.io/v2/nodes/bifc7/comments/?filter%5Btarget%5D=bifc7
                       meta: {}
                 registrations:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/registrations/
+                      href: https://api.osf.io/v2/nodes/bifc7/registrations/
                       meta: {}
                 node_links:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/node_links/
+                      href: https://api.osf.io/v2/nodes/bifc7/node_links/
                       meta: {}
                 linked_nodes:
                   links:
                     self:
-                      href: http://api.osf.io/v2/nodes/gaz5n/relationships/linked_nodes/
+                      href: https://api.osf.io/v2/nodes/bifc7/relationships/linked_nodes/
                       meta: {}
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/linked_nodes/
+                      href: https://api.osf.io/v2/nodes/bifc7/linked_nodes/
                       meta: {}
                 wikis:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/wikis/
+                      href: https://api.osf.io/v2/nodes/bifc7/wikis/
                       meta: {}
                 affiliated_institutions:
                   links:
                     self:
-                      href: http://api.osf.io/v2/nodes/gaz5n/relationships/institutions/
+                      href: https://api.osf.io/v2/nodes/bifc7/relationships/institutions/
                       meta: {}
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/institutions/
+                      href: https://api.osf.io/v2/nodes/bifc7/institutions/
                       meta: {}
                 children:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/children/
+                      href: https://api.osf.io/v2/nodes/bifc7/children/
                       meta: {}
                 preprints:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/preprints/
+                      href: https://api.osf.io/v2/nodes/bifc7/preprints/
                       meta: {}
                 logs:
                   links:
                     related:
-                      href: http://api.osf.io/v2/nodes/gaz5n/logs/
+                      href: https://api.osf.io/v2/nodes/bifc7/logs/
                       meta: {}
               links:
-                self: http://api.osf.io/v2/nodes/gaz5n/
-                html: http://osf.io/gaz5n/
+                self: https://api.osf.io/v2/nodes/bifc7/
+                html: https://osf.io/bifc7/
               attributes:
                 category: project
                 fork: false
                 preprint: false
-                description: 'Project description'
+                description: 'This is an independent replication as part of the Reproducibility
+                  Project: Psychology.'
                 current_user_permissions:
                 - read
-                - write
-                - admin
-                date_modified: '2017-03-20T20:13:30.599144'
-                title: 'Fantastic project title'
+                date_modified: '2017-03-03T05:00:31.512000'
+                title: Replication of WA Cunningham, JJ Van Bavel, IR Johnsen (2008, PS 19(2))
                 collection: false
                 registration: false
-                date_created: '2017-03-20T20:12:17.002426'
-                current_user_can_comment: true
+                date_created: '2014-07-28T13:53:04.508000'
+                current_user_can_comment: false
                 node_license:
-                public: false
+                public: true
                 tags: []
               type: nodes
-              id: gaz5n
+              id: bifc7
+            - relationships:
+                files:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/files/
+                      meta: {}
+                view_only_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/view_only_links/
+                      meta: {}
+                citation:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/citation/
+                      meta: {}
+                license:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/licenses/563c1cf88c5e4a3877f9e96a/
+                      meta: {}
+                contributors:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/contributors/
+                      meta: {}
+                forks:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/forks/
+                      meta: {}
+                root:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/
+                      meta: {}
+                identifiers:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/identifiers/
+                      meta: {}
+                forked_from:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/kxhz5/
+                      meta: {}
+                comments:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/comments/?filter%5Btarget%5D=73pnd
+                      meta: {}
+                registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/registrations/
+                      meta: {}
+                logs:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/logs/
+                      meta: {}
+                node_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/node_links/
+                      meta: {}
+                linked_nodes:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/73pnd/relationships/linked_nodes/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/linked_nodes/
+                      meta: {}
+                wikis:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/wikis/
+                      meta: {}
+                affiliated_institutions:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/73pnd/relationships/institutions/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/institutions/
+                      meta: {}
+                children:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/children/
+                      meta: {}
+                preprints:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/preprints/
+                      meta: {}
+                draft_registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/73pnd/draft_registrations/
+                      meta: {}
+              links:
+                self: https://api.osf.io/v2/nodes/73pnd/
+                html: https://osf.io/73pnd/
+              attributes:
+                category: project
+                fork: true
+                preprint: false
+                description:
+                current_user_permissions:
+                - read
+                date_modified: '2016-10-02T19:50:23.605000'
+                title: Replication of Hajcak &amp; Foti (2008, PS, Study 1)
+                collection: false
+                registration: false
+                date_created: '2012-10-31T18:50:46.111000'
+                current_user_can_comment: false
+                node_license:
+                  copyright_holders:
+                  - ''
+                  year: '2016'
+                public: true
+                tags:
+                - anxiety
+                - EMG
+                - EEG
+                - motivation
+                - ERN
+              type: nodes
+              id: 73pnd
+            - relationships:
+                files:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/files/
+                      meta: {}
+                view_only_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/view_only_links/
+                      meta: {}
+                citation:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/citation/
+                      meta: {}
+                draft_registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/draft_registrations/
+                      meta: {}
+                contributors:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/contributors/
+                      meta: {}
+                forks:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/forks/
+                      meta: {}
+                template_node:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/3mqkb/
+                      meta: {}
+                root:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/
+                      meta: {}
+                identifiers:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/identifiers/
+                      meta: {}
+                comments:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/comments/?filter%5Btarget%5D=mjasz
+                      meta: {}
+                registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/registrations/
+                      meta: {}
+                node_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/node_links/
+                      meta: {}
+                linked_nodes:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/mjasz/relationships/linked_nodes/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/linked_nodes/
+                      meta: {}
+                wikis:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/wikis/
+                      meta: {}
+                affiliated_institutions:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/mjasz/relationships/institutions/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/institutions/
+                      meta: {}
+                children:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/children/
+                      meta: {}
+                preprints:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/preprints/
+                      meta: {}
+                logs:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/mjasz/logs/
+                      meta: {}
+              links:
+                self: https://api.osf.io/v2/nodes/mjasz/
+                html: https://osf.io/mjasz/
+              attributes:
+                category: project
+                fork: false
+                preprint: false
+                description:
+                current_user_permissions:
+                - read
+                date_modified: '2016-08-31T18:16:25.056000'
+                title: Replication of Winawer, Huk, & Boroditsky (Psychological Science, 2008)
+                collection: false
+                registration: false
+                date_created: '2014-09-23T18:58:54.915000'
+                current_user_can_comment: false
+                node_license:
+                public: true
+                tags: []
+              type: nodes
+              id: mjasz
             links:
-              first:
-              last:
-              prev:
-              next:
-              meta:
-                total: 1
-                per_page: 10
+              first: null
+              last: null
+              prev: null
+              next: null
+              meta: null
+              total: 3
+              per_page: 10

--- a/swagger-spec/view_only_links/nodes.yaml
+++ b/swagger-spec/view_only_links/nodes.yaml
@@ -2,7 +2,7 @@ get:
   summary: List all nodes
   description: >-
 
-    A list of nodes associated with the View Only Link.
+    The list of nodes which this view only link gives read-only access to.
 
     #### Permissions
 

--- a/swagger-spec/view_only_links/nodes.yaml
+++ b/swagger-spec/view_only_links/nodes.yaml
@@ -1,1 +1,180 @@
-# /view_only_links/{link_id}/nodes/
+get:
+  summary: List all nodes
+  description: >-
+
+    A list of nodes associated with the View Only Link.
+
+    #### Permissions
+
+    This requires admin permissions on all nodes to be associated with this view only link.
+
+    #### Returns
+
+    Returns a JSON object containing `data` and `links` keys.
+
+    The `data` key contains an array of 10 nodes.
+    Each resource in the array is a separate node object and contains the full representation of the node, meaning additional requests to a node's detail view are not necessary.
+
+
+    The `links` key contains a dictionary of links that can be used for [pagination](#Introduction_pagination).
+
+
+    This request should never return an error.
+
+    #### Filtering
+
+    You can optionally request that the response only include nodes that match your filters by utilizing the `filter` query parameter, e.g.
+    https://api.osf.io/v2/nodes/?filter[title]=reproducibility.
+
+
+    Nodes may be filtered by their `id`, `title`, `category`, `description`, `public`, `tags`, `date_created`, `date_modified`, `root`, `parent`, `preprint`, and `contributors`.
+
+
+    Most fields are string fields and will be filtered using simple substring matching.
+    Public and preprint are boolean fields, and can be filtered using truthy values, such as **true**, **false**, **0** or **1**.
+    Note that quoting true or false in the query will cause the match to fail.
+
+  parameters:
+    - in: path
+      type: string
+      name: link_id
+      required: true
+      description: 'The unique identifier of the view only link.'
+
+  tags:
+    - View Only Links
+  operationId: view_only_links_node_list
+  x-response-schema: Node
+  responses:
+    '200':
+      description: OK
+      schema:
+        type: array
+        items:
+          $ref: '../nodes/definition.yaml'
+      examples:
+        application/json:
+            data:
+            - relationships:
+                files:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/files/
+                      meta: {}
+                view_only_links:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/view_only_links/
+                      meta: {}
+                citation:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/citation/
+                      meta: {}
+                draft_registrations:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/draft_registrations/
+                      meta: {}
+                contributors:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/contributors/
+                      meta: {}
+                forks:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/forks/
+                      meta: {}
+                root:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/
+                      meta: {}
+                identifiers:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/identifiers/
+                      meta: {}
+                comments:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/comments/?filter%5Btarget%5D=gaz5n
+                      meta: {}
+                registrations:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/registrations/
+                      meta: {}
+                node_links:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/node_links/
+                      meta: {}
+                linked_nodes:
+                  links:
+                    self:
+                      href: http://api.osf.io/v2/nodes/gaz5n/relationships/linked_nodes/
+                      meta: {}
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/linked_nodes/
+                      meta: {}
+                wikis:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/wikis/
+                      meta: {}
+                affiliated_institutions:
+                  links:
+                    self:
+                      href: http://api.osf.io/v2/nodes/gaz5n/relationships/institutions/
+                      meta: {}
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/institutions/
+                      meta: {}
+                children:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/children/
+                      meta: {}
+                preprints:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/preprints/
+                      meta: {}
+                logs:
+                  links:
+                    related:
+                      href: http://api.osf.io/v2/nodes/gaz5n/logs/
+                      meta: {}
+              links:
+                self: http://api.osf.io/v2/nodes/gaz5n/
+                html: http://osf.io/gaz5n/
+              attributes:
+                category: project
+                fork: false
+                preprint: false
+                description: 'Project description'
+                current_user_permissions:
+                - read
+                - write
+                - admin
+                date_modified: '2017-03-20T20:13:30.599144'
+                title: 'Fantastic project title'
+                collection: false
+                registration: false
+                date_created: '2017-03-20T20:12:17.002426'
+                current_user_can_comment: true
+                node_license:
+                public: false
+                tags: []
+              type: nodes
+              id: gaz5n
+            links:
+              first:
+              last:
+              prev:
+              next:
+              meta:
+                total: 1
+                per_page: 10


### PR DESCRIPTION
Purpose

Add view only link (VOL) endpoints documentation to the new API docs.

Changes

Adds model definition and yaml spec files for endpoints /view_only_links/<link_id>/ (detail.yaml)
/view_only_links/nodes/ (nodes_list.yaml).

Ticket

https://openscience.atlassian.net/browse/OSF-7470