### PR TITLE
[Feature] Add taxonomies list and detail endpoints [OSF-7467]

### DIFF
--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -294,3 +294,13 @@ paths:
 
   /wikis/{wiki_id}/content/:
     $ref: 'wikis/content.yaml'
+
+  ##################
+  #   TAXONOMIES   #
+  ##################
+
+  /taxonomies/:
+    $ref: 'taxonomies/list.yaml'
+
+  /taxonomies/{taxonomy_id}/:
+    $ref: 'taxonomies/detail.yaml'

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -263,6 +263,16 @@ paths:
   /registrations/{registration_id}/:
     $ref: 'registrations/detail.yaml'
 
+  ##################
+  #   TAXONOMIES   #
+  ##################
+
+  /taxonomies/:
+    $ref: 'taxonomies/list.yaml'
+
+  /taxonomies/{taxonomy_id}/:
+    $ref: 'taxonomies/detail.yaml'
+
   #############
   #   USERS   #
   #############
@@ -294,13 +304,3 @@ paths:
 
   /wikis/{wiki_id}/content/:
     $ref: 'wikis/content.yaml'
-
-  ##################
-  #   TAXONOMIES   #
-  ##################
-
-  /taxonomies/:
-    $ref: 'taxonomies/list.yaml'
-
-  /taxonomies/{taxonomy_id}/:
-    $ref: 'taxonomies/detail.yaml'

--- a/swagger-spec/taxonomies/definition.yaml
+++ b/swagger-spec/taxonomies/definition.yaml
@@ -22,7 +22,7 @@ properties:
       child_count:
         type: integer
         readOnly: true
-        description: 'Number of children this taxonomy contains.'
+        description: 'The number of children this taxonomy contains.'
       parents:
         type: array
         items:

--- a/swagger-spec/taxonomies/detail.yaml
+++ b/swagger-spec/taxonomies/detail.yaml
@@ -6,8 +6,9 @@ get:
 
     #### Returns
 
+
     Returns a JSON object with a `data` key containing the representation of the requested
-    PLOS taxonomy, if the request is successful.
+    taxonomy, if the request is successful.
 
 
     If the request is unsuccessful, an `errors` key containing

--- a/swagger-spec/taxonomies/detail.yaml
+++ b/swagger-spec/taxonomies/detail.yaml
@@ -1,1 +1,46 @@
 # /taxonomies/{taxonomy_id}/
+get:
+  summary: Retrieve a taxonomy
+  description: >-
+    Retrieves the details of a taxonomy.
+
+    #### Returns
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    PLOS taxonomy, if the request is successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+    to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: taxonomy_id
+      description: 'The unique identifier of the taxonomy.'
+  tags:
+    - Taxonomies
+  operationId: taxonomies_read
+  x-response-schema: Taxonomy
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: 'definition.yaml'
+      examples:
+        application/json:
+          data:
+            links:
+              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca841/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240da54be81056cecab8f/
+            attributes:
+              text: Public Economics
+              parents:
+              - text: Economics
+                id: 584240da54be81056cecab8f
+              child_count: 0
+            type: taxonomies
+            id: 584240d954be81056ceca841

--- a/swagger-spec/taxonomies/list.yaml
+++ b/swagger-spec/taxonomies/list.yaml
@@ -1,1 +1,175 @@
 # /taxonomies/
+get:
+  summary: List all taxonomies
+  description: >-
+
+    A paginated list of all [PLOS taxonomies of subjects](http://journals.plos.org/plosone/browse/).
+
+    Note: this API endpoint is under active development, and is subject to change in the future.
+
+    #### Returns
+
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains an array of up to 10 taxonomies.
+    Each resource in the array is a separate taxonomy object.
+
+
+    The `links` key contains a dictionary of links that can be used
+    for [pagination](#Introduction_pagination).
+
+
+    This request should never return an error.
+
+    #### Filtering
+
+    You can optionally request that the response only include subjects that
+    match your filters by utilizing the `filter` query parameter, e.g.
+    https://api.osf.io/v2/preprints/?filter['id']='{subject_id}'.
+
+
+    Subjects may be filtered by their `id`, `parents`, and `text`.
+
+  tags:
+    - Taxonomies
+  operationId: taxonomies_list
+  x-response-schema: Taxonomy
+  responses:
+    '200':
+      description: OK
+      schema:
+        type: array
+        items:
+          $ref: 'definition.yaml'
+      examples:
+        application/json:
+          data:
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d854be81056ceca838/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240d954be81056ceca97a/
+            attributes:
+              text: History of Philosophy
+              parents:
+              - text: Philosophy
+                id: 584240d954be81056ceca97a
+              child_count: 0
+            type: taxonomies
+            id: 584240d854be81056ceca838
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d854be81056ceca839/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240db54be81056cecacd3/
+            attributes:
+              text: Animal Law
+              parents:
+              - text: Law
+                id: 584240db54be81056cecacd3
+              child_count: 0
+            type: taxonomies
+            id: 584240d854be81056ceca839
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d854be81056ceca83a/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240db54be81056cecacd3/
+            attributes:
+              text: Consumer Protection Law
+              parents:
+              - text: Law
+                id: 584240db54be81056cecacd3
+              child_count: 0
+            type: taxonomies
+            id: 584240d854be81056ceca83a
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d854be81056ceca83b/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240da54be81056cecaa9c/
+            attributes:
+              text: Missions and World Christianity
+              parents:
+              - text: Religion
+                id: 584240da54be81056cecaa9c
+              child_count: 0
+            type: taxonomies
+            id: 584240d854be81056ceca83b
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d854be81056ceca83c/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240d954be81056ceca8fd/
+            attributes:
+              text: Other Teacher Education and Professional Development
+              parents:
+              - text: Teacher Education and Professional Development
+                id: 584240d954be81056ceca8fd
+              child_count: 0
+            type: taxonomies
+            id: 584240d854be81056ceca83c
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca83d/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240d954be81056ceca938/
+            attributes:
+              text: Other Educational Administration and Supervision
+              parents:
+              - text: Educational Administration and Supervision
+                id: 584240d954be81056ceca938
+              child_count: 0
+            type: taxonomies
+            id: 584240d954be81056ceca83d
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca83e/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240d954be81056ceca953/
+            attributes:
+              text: Russian Linguistics
+              parents:
+              - text: Slavic Languages and Societies
+                id: 584240d954be81056ceca953
+              child_count: 0
+            type: taxonomies
+            id: 584240d954be81056ceca83e
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca83f/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240d954be81056cecaa24/
+            attributes:
+              text: Medicinal Chemistry and Pharmaceutics
+              parents:
+              - text: Pharmacology, Toxicology and Environmental Health
+                id: 584240d954be81056cecaa24
+              child_count: 0
+            type: taxonomies
+            id: 584240d954be81056ceca83f
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca840/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240da54be81056cecac49/
+            attributes:
+              text: Poetry
+              parents:
+              - text: Creative Writing
+                id: 584240da54be81056cecac49
+              child_count: 0
+            type: taxonomies
+            id: 584240d954be81056ceca840
+          - links:
+              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca841/
+              parents:
+              - https://api.osf.io/v2/taxonomies/584240da54be81056cecab8f/
+            attributes:
+              text: Public Economics
+              parents:
+              - text: Economics
+                id: 584240da54be81056cecab8f
+              child_count: 0
+            type: taxonomies
+            id: 584240d954be81056ceca841
+          links:
+            first:
+            last: https://api.osf.io/v2/taxonomies/?page=122
+            prev:
+            next: https://api.osf.io/v2/taxonomies/?page=2
+            meta:
+            total: 1217
+            per_page: 10

--- a/swagger-spec/taxonomies/list.yaml
+++ b/swagger-spec/taxonomies/list.yaml
@@ -3,7 +3,7 @@ get:
   summary: List all taxonomies
   description: >-
 
-    A paginated list of all [PLOS taxonomies of subjects](http://journals.plos.org/plosone/browse/).
+    A paginated list of all [bepress disciplines taxonomies](https://www.bepress.com/wp-content/uploads/2016/12/Digital-Commons-Disciplines-taxonomy-2017-01.pdf).
 
     Note: this API endpoint is under active development, and is subject to change in the future.
 
@@ -24,12 +24,12 @@ get:
 
     #### Filtering
 
-    You can optionally request that the response only include subjects that
+    You can optionally request that the response only include taxonomies that
     match your filters by utilizing the `filter` query parameter, e.g.
-    https://api.osf.io/v2/preprints/?filter['id']='{subject_id}'.
+    https://api.osf.io/v2/taxonomies/?filter['id']='{taxonomy_id}'.
 
 
-    Subjects may be filtered by their `id`, `parents`, and `text`.
+    Taxonomies may be filtered by their `id`, `parents`, and `text`.
 
   tags:
     - Taxonomies
@@ -105,71 +105,11 @@ get:
               child_count: 0
             type: taxonomies
             id: 584240d854be81056ceca83c
-          - links:
-              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca83d/
-              parents:
-              - https://api.osf.io/v2/taxonomies/584240d954be81056ceca938/
-            attributes:
-              text: Other Educational Administration and Supervision
-              parents:
-              - text: Educational Administration and Supervision
-                id: 584240d954be81056ceca938
-              child_count: 0
-            type: taxonomies
-            id: 584240d954be81056ceca83d
-          - links:
-              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca83e/
-              parents:
-              - https://api.osf.io/v2/taxonomies/584240d954be81056ceca953/
-            attributes:
-              text: Russian Linguistics
-              parents:
-              - text: Slavic Languages and Societies
-                id: 584240d954be81056ceca953
-              child_count: 0
-            type: taxonomies
-            id: 584240d954be81056ceca83e
-          - links:
-              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca83f/
-              parents:
-              - https://api.osf.io/v2/taxonomies/584240d954be81056cecaa24/
-            attributes:
-              text: Medicinal Chemistry and Pharmaceutics
-              parents:
-              - text: Pharmacology, Toxicology and Environmental Health
-                id: 584240d954be81056cecaa24
-              child_count: 0
-            type: taxonomies
-            id: 584240d954be81056ceca83f
-          - links:
-              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca840/
-              parents:
-              - https://api.osf.io/v2/taxonomies/584240da54be81056cecac49/
-            attributes:
-              text: Poetry
-              parents:
-              - text: Creative Writing
-                id: 584240da54be81056cecac49
-              child_count: 0
-            type: taxonomies
-            id: 584240d954be81056ceca840
-          - links:
-              self: https://api.osf.io/v2/taxonomies/584240d954be81056ceca841/
-              parents:
-              - https://api.osf.io/v2/taxonomies/584240da54be81056cecab8f/
-            attributes:
-              text: Public Economics
-              parents:
-              - text: Economics
-                id: 584240da54be81056cecab8f
-              child_count: 0
-            type: taxonomies
-            id: 584240d954be81056ceca841
           links:
             first:
-            last: https://api.osf.io/v2/taxonomies/?page=122
+            last:
             prev:
-            next: https://api.osf.io/v2/taxonomies/?page=2
+            next:
             meta:
-            total: 1217
+            total: 5
             per_page: 10


### PR DESCRIPTION
#### Purpose
Add documentations for remaining taxonomies endpoints.

#### Changes
- Adds taxonomies detail endpoint (/taxonomies/<taxonomy_id>/ ) documentation (detail.yaml).
- Adds taxonomies list endpoint (/taxonomies/) documentation (list.yaml).

#### Ticket
- [OSF-7467](https://openscience.atlassian.net/browse/OSF-7467)
