### PR TITLE
[Feature] Add identifiers model definition, list, detail endpoints documentation [OSF-7453]

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('validate', function() {
  * Watch for changes and recompile
  */
 gulp.task('watch', function() {
-  return watch(['./src/**/*.{js,less,handlebars}', './swagger-spec/**/*.yaml'], function() {
+  return watch(['./src/**/*.{js,less,handlebars}'], function() {
     gulp.start('default');
   });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('validate', function() {
  * Watch for changes and recompile
  */
 gulp.task('watch', function() {
-  return watch(['./src/**/*.{js,less,handlebars}'], function() {
+  return watch(['./src/**/*.{js,less,handlebars}', './swagger-spec/**/*.yaml'], function() {
     gulp.start('default');
   });
 });

--- a/swagger-spec/identifiers/definition.yaml
+++ b/swagger-spec/identifiers/definition.yaml
@@ -21,7 +21,7 @@ properties:
           - ark
           - doi
         readOnly: true
-        description: 'The category of this identifier'
+        description: 'The category of the identifier'
       value:
         type: string
         readOnly: true

--- a/swagger-spec/identifiers/definition.yaml
+++ b/swagger-spec/identifiers/definition.yaml
@@ -17,8 +17,11 @@ properties:
     properties:
       category:
         type: string
+        enum:
+          - ark
+          - doi
         readOnly: true
-        description: 'category can be ark or doi'
+        description: 'The category of this identifier'
       value:
         type: string
         readOnly: true

--- a/swagger-spec/identifiers/definition.yaml
+++ b/swagger-spec/identifiers/definition.yaml
@@ -1,0 +1,47 @@
+type: object
+title: Identifier
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The identifier of the identifier entity.'
+  type:
+    type: string
+    readOnly: true
+    description: 'The type identifier of the identifier entity (`identifiers`).'
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: true
+    description: 'The properties of the identifier entity.'
+    properties:
+      category:
+        type: string
+        readOnly: true
+        description: 'ark or doi'
+      value:
+        type: string
+        readOnly: true
+        description: 'The identifier value itself'
+  relationships:
+    type: object
+    title: Relationships
+    readOnly: true
+    description: 'URLs to other entities or entity collections that have a relationship to the identifier entity.'
+    properties:
+      referent:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'A relationship to the node the identifier refers to.'
+  links:
+    type: object
+    title: Links
+    readOnly: true
+    description: 'URLs to alternative representations of the identifier entity.'
+    properties:
+      self:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'A link to the detail page for the identifier.'

--- a/swagger-spec/identifiers/definition.yaml
+++ b/swagger-spec/identifiers/definition.yaml
@@ -18,7 +18,7 @@ properties:
       category:
         type: string
         readOnly: true
-        description: 'ark or doi'
+        description: 'category can be ark or doi'
       value:
         type: string
         readOnly: true

--- a/swagger-spec/identifiers/detail.yaml
+++ b/swagger-spec/identifiers/detail.yaml
@@ -1,1 +1,47 @@
 # /identifiers/{identifier_id}/
+get:
+  summary: Retrieve an identifier
+  description: >-
+    Retrieves the details of an identifier
+
+    ####Returns
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    identifier, if the request was successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+    to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: identifier_id
+      description: 'The unique id of the identifier.'
+  tags:
+    - Identifiers
+  operationId: identifiers_read
+  x-response-schema: Identifier
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: definition.yaml
+      examples:
+        application/json:
+          data:
+            relationships:
+              referent:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/nodes/73pnd/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b45a/
+            attributes:
+              category: ark
+              value: c7605/osf.io/73pnd
+            type: identifiers
+            id: 57f1641db83f6901ed94b45a

--- a/swagger-spec/identifiers/list.yaml
+++ b/swagger-spec/identifiers/list.yaml
@@ -18,7 +18,7 @@ get:
     ####Filtering
 
     You can optionally request that the response only include identifiers that match your filters by utilizing the `filter` query parameter, e.g.
-    https://api.osf.io/v2/nodes/?filter[category]=doi.
+    https://api.osf.io/v2/identifiers/73pnd/identifiers/?filter[category]=doi.
 
     Identifiers may be filtered by their `category` e.g `ark` or `doi`.
 

--- a/swagger-spec/identifiers/list.yaml
+++ b/swagger-spec/identifiers/list.yaml
@@ -1,1 +1,80 @@
 # /identifiers/{node_id}/identifiers/
+get:
+  summary: List all identifiers
+  description: >-
+    List of all identifiers for a given node.
+
+    ####Returns
+
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains an array of identifiers.
+    Each resource in the array is a separate identifier object.
+
+
+    The `links` key contains a dictionary of links that can be used for [pagination](#Introduction_pagination).
+
+    ####Filtering
+
+    You can optionally request that the response only include identifiers that match your filters by utilizing the `filter` query parameter, e.g.
+    https://api.osf.io/v2/nodes/?filter[category]=doi.
+
+    Identifiers may be filtered by their `category` e.g `ark` or `doi`.
+
+  parameters:
+
+    - in: path
+      name: node_id
+      type: string
+      required: true
+      description: 'The unique identifier of the node.'
+
+  tags:
+    - Identifiers
+  operationId: identifiers_list
+  x-response-schema: Identifier
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        type: array
+        items:
+          $ref: definition.yaml
+      examples:
+        application/json:
+          data:
+          - relationships:
+              referent:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/nodes/73pnd/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b459/
+            attributes:
+              category: doi
+              value: 10.17605/OSF.IO/73PND
+            type: identifiers
+            id: 57f1641db83f6901ed94b459
+          - relationships:
+              referent:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/nodes/73pnd/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b45a/
+            attributes:
+              category: ark
+              value: c7605/osf.io/73pnd
+            type: identifiers
+            id: 57f1641db83f6901ed94b45a
+          links:
+            first:
+            last:
+            prev:
+            next:
+            meta:
+            total: 2
+            per_page: 10


### PR DESCRIPTION
#### Purpose

Add documentation for all identifiers endpoints.

#### Changes

- Creates identifiers model definition.
- Adds identifiers detail endpoint (/identifiers/<identifier_id>/) documentation (detail.yaml).
- Adds identifiers list endpoint (//identifiers/<node_id>/identifiers/) documentation (list.yaml).

#### Ticket
- [OSF-7453](https://openscience.atlassian.net/browse/OSF-7453)
