### PR TITLE
[Feature] Add addon model definition and list endpoint documentation [OSF-7445]

### DIFF
--- a/swagger-spec/addons/definition.yaml
+++ b/swagger-spec/addons/definition.yaml
@@ -1,0 +1,36 @@
+type: object
+title: Addon
+properties:
+  links: {}
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: false
+    description: The properties of the addon entity.
+    properties:
+      url:
+        type: string
+        readOnly: true
+        description: Url to the third-party service.
+      name:
+        type: string
+        readOnly: true
+        description: Full name of the third-party service provider.
+      description:
+        type: string
+        readOnly: true
+        description: Description of the addon.
+      categories:
+        type: array
+        items:
+          type: string
+        readOnly: true
+        description: List of categories this addon belongs to.
+  type  :
+    type: string
+    readOnly: true
+    description: The type identifier of the institution entity (`addons`).
+  id:
+    type: string
+    readOnly: true
+    description: The identifier of the addon entity.

--- a/swagger-spec/addons/definition.yaml
+++ b/swagger-spec/addons/definition.yaml
@@ -1,35 +1,42 @@
 type: object
 title: Addon
 properties:
-  links: {}
   attributes:
     type: object
     title: Attributes
-    readOnly: false
+    readOnly: true
     description: The properties of the addon entity.
     properties:
       url:
         type: string
         readOnly: true
-        description: Url to the third-party service.
+        description: The URL to the third-party service provider.
       name:
         type: string
         readOnly: true
-        description: Full name of the third-party service provider.
+        description: The name of the third-party service provider.
       description:
         type: string
         readOnly: true
-        description: Description of the addon.
+        description: The description of the service provider.
       categories:
         type: array
         items:
           type: string
+          enum:
+            - documentation
+            - storage
+            - bibliography
+            - other
+            - security
+            - citations
         readOnly: true
         description: List of categories this addon belongs to.
   type  :
     type: string
     readOnly: true
-    description: The type identifier of the institution entity (`addons`).
+    description: The type identifier of the addon entity (`addons`).
+
   id:
     type: string
     readOnly: true

--- a/swagger-spec/addons/list.yaml
+++ b/swagger-spec/addons/list.yaml
@@ -1,1 +1,150 @@
 # /addons/
+get:
+  summary: List all addons
+  description: >-
+
+    A paginated list of addons configurable with the OSF
+
+    #### Returns
+
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains an array of up to 10 addons.
+    Each resource in the array is a separate addon object.
+
+
+    The `links` key contains a dictionary of links that can be used
+    for [pagination](#Introduction_pagination).
+
+
+    This request should never return an error.
+
+  tags:
+    - Addons
+  operationId: addons_list
+  x-response-schema: Addon
+  responses:
+    '200':
+      description: OK
+      schema:
+        type: array
+        items:
+          $ref: 'definition.yaml'
+      examples:
+        application/json:
+          data:
+          - links: {}
+            attributes:
+              url: http://www.box.com
+              name: Box
+              categories:
+              - storage
+              description: Box is a file storage add-on. Connect your Box account to an OSF
+                project to interact with files hosted on Box via the OSF.
+            type: addon
+            id: box
+          - links: {}
+            attributes:
+              url: https://dataverse.harvard.edu/
+              name: Dataverse
+              categories:
+              - storage
+              description: Dataverse is an open source software application to share, cite,
+                and archive data. Connect your Dataverse account to share your Dataverse datasets
+                via the OSF.
+            type: addon
+            id: dataverse
+          - links: {}
+            attributes:
+              url: http://www.dropbox.com
+              name: Dropbox
+              categories:
+              - storage
+              description: Dropbox is a file storage add-on. Connect your Dropbox account to
+                an OSF project to interact with files hosted on Dropbox via the OSF.
+            type: addon
+            id: dropbox
+          - links: {}
+            attributes:
+              url: http://www.figshare.com
+              name: figshare
+              categories:
+              - storage
+              description: Figshare is an online digital repository. Connect your figshare account
+                to share your figshare files along with other materials in your OSF project.
+            type: addon
+            id: figshare
+          - links: {}
+            attributes:
+              url: http://www.github.com
+              name: GitHub
+              categories:
+              - storage
+              description: GitHub is a web-based Git repository hosting service. Connect your
+                GitHub repo to your OSF project to share your code alongside other materials
+                in your OSF project.
+            type: addon
+            id: github
+          - links: {}
+            attributes:
+              url: http://www.mendeley.com
+              name: Mendeley
+              categories:
+              - citations
+              description: Mendeley is a reference management tool. Connecting Mendeley folders
+                to OSF projects allows you and others to view, copy, and download citations
+                that are relevant to your project from the Project Overview page.
+            type: addon
+            id: mendeley
+          - links: {}
+            attributes:
+              url: http://www.zotero.org
+              name: Zotero
+              categories:
+              - citations
+              description: Zotero is a reference management tool. Connecting Zotero folders
+                to OSF projects allows you and others to view, copy, and download citations
+                that are relevant to your project from the Project Overview page.
+            type: addon
+            id: zotero
+          - links: {}
+            attributes:
+              url: https://owncloud.org/
+              name: ownCloud
+              categories:
+              - storage
+              description: ownCloud is an open source, self-hosted file sync and share app platform.
+                Connect your ownCloud account to an OSF project to interact with files hosted
+                on ownCloud via the OSF.
+            type: addon
+            id: owncloud
+          - links: {}
+            attributes:
+              url: https://aws.amazon.com/s3/
+              name: Amazon S3
+              categories:
+              - storage
+              description: Amazon S3 is a file storage add-on. Connect your S3 account to an
+                OSF project to interact with files hosted on S3 via the OSF.
+            type: addon
+            id: s3
+          - links: {}
+            attributes:
+              url: https://drive.google.com
+              name: Google Drive
+              categories:
+              - storage
+              description: Google Drive is a file storage add-on. Connect your Google Drive
+                account to an OSF project to interact with files hosted on Google Drive via
+                the OSF.
+            type: addon
+            id: googledrive
+          links:
+            first:
+            last:
+            prev:
+            next:
+            meta:
+            total: 10
+            per_page: 1000

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -294,3 +294,11 @@ paths:
 
   /wikis/{wiki_id}/content/:
     $ref: 'wikis/content.yaml'
+
+
+  ##############
+  #   ADDONS   #
+  ##############
+
+  /addons/:
+    $ref: 'addons/list.yaml'

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -63,6 +63,13 @@ paths:
   /versioning/:
     $ref: 'introduction/versioning.yaml'
 
+  ##############
+  #   ADDONS   #
+  ##############
+
+  /addons/:
+    $ref: 'addons/list.yaml'
+
   ############
   #   BASE   #
   ############
@@ -294,11 +301,3 @@ paths:
 
   /wikis/{wiki_id}/content/:
     $ref: 'wikis/content.yaml'
-
-
-  ##############
-  #   ADDONS   #
-  ##############
-
-  /addons/:
-    $ref: 'addons/list.yaml'


### PR DESCRIPTION
#### Purpose

Add documentation for addon endpoints.

#### Changes

- Creates addons model definition.
- Adds addons list endpoint (/addons/) documentation (list.yaml).

#### Ticket
- [OSF-7445](https://openscience.atlassian.net/browse/OSF-7445)
