### PR TITLE
[Feature] Add example body for comments create endpoint.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('validate', function() {
  * Watch for changes and recompile
  */
 gulp.task('watch', function() {
-  return watch(['./src/**/*.{js,less,handlebars}', './swagger-spec/**/*.yaml'], function() {
+  return watch(['./src/**/*.{js,less,handlebars}'], function() {
     gulp.start('default');
   });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('validate', function() {
  * Watch for changes and recompile
  */
 gulp.task('watch', function() {
-  return watch(['./src/**/*.{js,less,handlebars}'], function() {
+  return watch(['./src/**/*.{js,less,handlebars}', './swagger-spec/**/*.yaml'], function() {
     gulp.start('default');
   });
 });

--- a/swagger-spec/comments/definition.yaml
+++ b/swagger-spec/comments/definition.yaml
@@ -13,7 +13,7 @@ properties:
     description: 'The type identifier of the comment entity (`comments`).'
   attributes:
     type: object
-    title: Attibutes
+    title: Attributes
     readOnly: false
     description: 'The properties of the comment entity.'
     properties:

--- a/swagger-spec/comments/definition.yaml
+++ b/swagger-spec/comments/definition.yaml
@@ -109,9 +109,9 @@ example:
   data:
     type: comments
     attributes:
-      content: 'An excellent reply to your comment'
+      content: 'comment content'
     relationships:
       target:
         data:
-          type: 'comments'
-          id: '{comment_id}'
+          type: '{target_type}'
+          id: '{target_id}'

--- a/swagger-spec/comments/definition.yaml
+++ b/swagger-spec/comments/definition.yaml
@@ -105,3 +105,13 @@ properties:
         format: URL
         readOnly: true
         description: 'A link to the detail page for the comment.'
+example:
+  data:
+    type: comments
+    attributes:
+      content: 'An excellent reply to your comment'
+    relationships:
+      target:
+        data:
+          type: 'comments'
+          id: '{comment_id}'


### PR DESCRIPTION
#### Purpose

Add example body for create operation.

#### Changes

- Add example body for comments create endpoint in the /comments/definition.yaml.

#### Ticket

