### PR TITLE
[Feature] Add documentation for user addons endpoints [OSF-7469]

### DIFF
--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -311,6 +311,19 @@ paths:
   /users/{user_id}/registrations/:
     $ref: 'users/registrations_list.yaml'
 
+  /users/{user_id}/addons/:
+    $ref: 'users/addons_list.yaml'
+
+  /users/{user_id}/addons/{provider}:
+    $ref: 'users/addon_detail.yaml'
+
+  /users/{user_id}/addons/{provider}/accounts/:
+    $ref: 'users/addon_accounts_list.yaml'
+
+  /users/{user_id}/addons/{provider}/accounts/{account_id}/:
+    $ref: 'users/addon_account_detail.yaml'
+
+
   ######################
   #   View Only Links  #
   ######################
@@ -319,7 +332,7 @@ paths:
     $ref: 'view_only_links/detail.yaml'
   /view_only_links/{link_id}/nodes/:
     $ref: 'view_only_links/nodes.yaml'
-    
+
   #############
   #   WIKIS   #
   #############

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -314,7 +314,7 @@ paths:
   /users/{user_id}/addons/:
     $ref: 'users/addons_list.yaml'
 
-  /users/{user_id}/addons/{provider}:
+  /users/{user_id}/addons/{provider}/:
     $ref: 'users/addon_detail.yaml'
 
   /users/{user_id}/addons/{provider}/accounts/:

--- a/swagger-spec/users/addon_account_definition.yaml
+++ b/swagger-spec/users/addon_account_definition.yaml
@@ -1,0 +1,51 @@
+type: object
+title: External Account
+required:
+  - id
+  - type
+  - attributes
+  - links
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The unique identifier of the external (addon) account entity.'
+
+  type:
+    type: string
+    readOnly: true
+    description: 'The type identifier of the external (addon) account entity (`external_accounts`).'
+
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: true
+    description: 'The properties of the external (addon) account entity.'
+    required:
+      - display_name
+      - provider
+    properties:
+      display_name:
+        type: string
+        readOnly: true
+        description: 'The user''s display name on the third-party service'
+      provider:
+        type: string
+        readOnly: true
+        description: 'The short name of the third-party service'
+      profile_url:
+        type: string
+        readOnly: true
+        description: 'The link to user''s profile on third-party service'
+
+  links:
+    type: object
+    title: Links
+    readOnly: true
+    description: 'URLs to alternative representations of the external (addon) account entity.'
+    properties:
+      self:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'The canonical api endpoint of this external (addon) account'

--- a/swagger-spec/users/addon_account_definition.yaml
+++ b/swagger-spec/users/addon_account_definition.yaml
@@ -1,5 +1,5 @@
 type: object
-title: External Account
+title: Addon Account
 required:
   - id
   - type
@@ -9,18 +9,18 @@ properties:
   id:
     type: string
     readOnly: true
-    description: 'The unique identifier of the external (addon) account entity.'
+    description: 'The unique identifier of the addon account entity.'
 
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the external (addon) account entity (`external_accounts`).'
+    description: 'The type identifier of the addon account entity (`external_accounts`).'
 
   attributes:
     type: object
     title: Attributes
     readOnly: true
-    description: 'The properties of the external (addon) account entity.'
+    description: 'The properties of the addon account entity.'
     required:
       - display_name
       - provider
@@ -42,10 +42,10 @@ properties:
     type: object
     title: Links
     readOnly: true
-    description: 'URLs to alternative representations of the external (addon) account entity.'
+    description: 'URLs to alternative representations of the addon account entity.'
     properties:
       self:
         type: string
         format: URL
         readOnly: true
-        description: 'The canonical api endpoint of this external (addon) account'
+        description: 'The canonical api endpoint of this addon account'

--- a/swagger-spec/users/addon_account_detail.yaml
+++ b/swagger-spec/users/addon_account_detail.yaml
@@ -2,19 +2,19 @@
 get:
   summary: Retrieve an addon account
   description: >-
-    Retrieves the details of an external (addon) account
+    Retrieves the details of an addon account
 
 
     #### Permissions
 
 
-    External accounts are visible only to the user that has ownership of them.
+    Addon accounts are visible only to the user that has ownership of them.
 
 
     ####Returns
 
     Returns a JSON object with a `data` key containing the representation of the requested
-    external account, if the request was successful.
+    addon account, if the request was successful.
 
 
     If the request is unsuccessful, an `errors` key containing
@@ -36,13 +36,13 @@ get:
       name: account_id
       type: string
       required: true
-      description: 'The unique identifier of the external account.'
+      description: 'The unique identifier of the addon account.'
 
 
   tags:
     - Users
   operationId: Users_addon_accounts_read
-  x-response-schema: External Account
+  x-response-schema: Addon Account
   responses:
     '200':
       description: 'OK'

--- a/swagger-spec/users/addon_account_detail.yaml
+++ b/swagger-spec/users/addon_account_detail.yaml
@@ -8,7 +8,7 @@ get:
     #### Permissions
 
 
-    Addon accounts are visible only to the user that has ownership of them.
+    Addon accounts are visible only to the user that authorized the account.
 
 
     ####Returns

--- a/swagger-spec/users/addon_account_detail.yaml
+++ b/swagger-spec/users/addon_account_detail.yaml
@@ -1,1 +1,62 @@
 # /users/{user_id}/addons/{provider}/accounts/{account_id}/
+get:
+  summary: Retrieve an addon account
+  description: >-
+    Retrieves the details of an external (addon) account
+
+
+    #### Permissions
+
+
+    External accounts are visible only to the user that has ownership of them.
+
+
+    ####Returns
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    external account, if the request was successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+    to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: user_id
+      description: 'The unique identifier of the user.'
+    - in: path
+      name: provider
+      type: string
+      required: true
+      description: 'The unique identifier of the addon provider.'
+    - in: path
+      name: account_id
+      type: string
+      required: true
+      description: 'The unique identifier of the external account.'
+
+
+  tags:
+    - Users
+  operationId: Users_addon_accounts_read
+  x-response-schema: External Account
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: 'addon_account_definition.yaml'
+      examples:
+        application/json:
+          data:
+            data:
+              links:
+                self: https://api.osf.io/v2/users/me/addons/dropbox/accounts/58d16ece9ad5a10201027eb4/
+              attributes:
+                display_name: Fabrice Mizero
+                profile_url:
+                provider: dropbox
+              type: external_accounts
+              id: 58d16ece9ad5a10201027eb4

--- a/swagger-spec/users/addon_accounts_list.yaml
+++ b/swagger-spec/users/addon_accounts_list.yaml
@@ -9,7 +9,7 @@ get:
     #### Permissions
 
 
-    Addon accounts are visible only to the user that has ownership of them.
+    Addon accounts are visible only to the user that authorized the account.
 
 
     #### Returns

--- a/swagger-spec/users/addon_accounts_list.yaml
+++ b/swagger-spec/users/addon_accounts_list.yaml
@@ -3,13 +3,13 @@ get:
   summary: List all addon accounts
   description: >-
 
-    A paginated list of external (addon) accounts authorized by this user.
+    A paginated list of addon accounts authorized by this user.
 
 
     #### Permissions
 
 
-    External accounts are visible only to the user that has ownership of them.
+    Addon accounts are visible only to the user that has ownership of them.
 
 
     #### Returns
@@ -17,9 +17,9 @@ get:
     Returns a JSON object containing `data` and `links` keys.
 
 
-    The `data` key contains an array of at most 10 external account objects.
-    Each resource in the array is a separate  external account object and
-    contains the full representation of the external account.
+    The `data` key contains an array of at most 10 addon account objects.
+    Each resource in the array is a separate  addon account object and
+    contains the full representation of the addon account.
 
 
     The `links` key contains a dictionary of links that can be used for [pagination](#Introduction_pagination).
@@ -39,7 +39,7 @@ get:
   tags:
     - Users
   operationId: Users_addon_accounts_list
-  x-response-schema: External Account
+  x-response-schema: Addon Account
   responses:
     '200':
       description: OK

--- a/swagger-spec/users/addon_accounts_list.yaml
+++ b/swagger-spec/users/addon_accounts_list.yaml
@@ -1,1 +1,68 @@
 # /users/{user_id}/addons/{provider}/accounts/
+get:
+  summary: List all addon accounts
+  description: >-
+
+    A paginated list of external (addon) accounts authorized by this user.
+
+
+    #### Permissions
+
+
+    External accounts are visible only to the user that has ownership of them.
+
+
+    #### Returns
+
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains an array of at most 10 external account objects.
+    Each resource in the array is a separate  external account object and
+    contains the full representation of the external account.
+
+
+    The `links` key contains a dictionary of links that can be used for [pagination](#Introduction_pagination).
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: user_id
+      description: 'The unique identifier of the user.'
+    - in: path
+      name: provider
+      type: string
+      required: true
+      description: 'The unique identifier of the addon provider.'
+
+  tags:
+    - Users
+  operationId: Users_addon_accounts_list
+  x-response-schema: External Account
+  responses:
+    '200':
+      description: OK
+      schema:
+        type: array
+        items:
+          $ref: 'addon_account_definition.yaml'
+      examples:
+        application/json:
+          data:
+          - links:
+              self: https://api.osf.io/v2/users/me/addons/dropbox/accounts/58d16ece9ad5a10201027eb4/
+            attributes:
+              display_name: 'Fabrice Mizero'
+              profile_url:
+              provider: dropbox
+            type: external_accounts
+            id: 58d16ece9ad5a10201027eb4
+          links:
+            first:
+            last:
+            prev:
+            next:
+            meta:
+              total: 1
+              per_page: 10

--- a/swagger-spec/users/addon_detail.yaml
+++ b/swagger-spec/users/addon_detail.yaml
@@ -1,13 +1,20 @@
 # /users/{user_id}/addons/{provider}/
 get:
-  summary: Retrieve an addon
+  summary: Retrieve a user addon
   description: >-
-    Retrieves the details of a user addon
+    Retrieves the details of an authorized user addon
+
+
+    #### Permissions
+
+
+    User addons are visible only to the user that has ownership of them.
+
 
     ####Returns
 
     Returns a JSON object with a `data` key containing the representation of the requested
-    addon, if the request was successful.
+    user addon, if the request was successful.
 
 
     If the request is unsuccessful, an `errors` key containing
@@ -26,16 +33,15 @@ get:
       required: true
       description: 'The unique identifier of the addon provider.'
 
-
   tags:
     - Users
   operationId: users_addons_read
-  x-response-schema: Addon
+  x-response-schema: User Addon
   responses:
     '200':
       description: 'OK'
       schema:
-        $ref: '../addons/definition.yaml'
+        $ref: 'user_addon_definition.yaml'
       examples:
         application/json:
           data:

--- a/swagger-spec/users/addon_detail.yaml
+++ b/swagger-spec/users/addon_detail.yaml
@@ -8,7 +8,7 @@ get:
     #### Permissions
 
 
-    User addons are visible only to the user that has ownership of them.
+    User addons are visible only to the user that authorized the addon.
 
 
     ####Returns
@@ -21,6 +21,8 @@ get:
     information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
     to understand why this request may have failed.
 
+
+    Attempting to request the accounts for an addon that is not enabled will result in a **404 Not Found** response.
   parameters:
     - in: path
       type: string

--- a/swagger-spec/users/addon_detail.yaml
+++ b/swagger-spec/users/addon_detail.yaml
@@ -1,1 +1,51 @@
 # /users/{user_id}/addons/{provider}/
+get:
+  summary: Retrieve an addon
+  description: >-
+    Retrieves the details of a user addon
+
+    ####Returns
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    addon, if the request was successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+    to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: user_id
+      description: 'The unique identifier of the user.'
+    - in: path
+      name: provider
+      type: string
+      required: true
+      description: 'The unique identifier of the addon provider.'
+
+
+  tags:
+    - Users
+  operationId: users_addons_read
+  x-response-schema: Addon
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: '../addons/definition.yaml'
+      examples:
+        application/json:
+          data:
+            links:
+              self: https://api.osf.io/v2/users/me/addons/dropbox/
+              accounts:
+                58d16ece9ad5a10201025eb4:
+                  nodes_connected: []
+                  account: https://api.osf.io/v2/users/f542f/addons/dropbox/accounts/58d16ece9ad5a10201025eb4/
+            attributes:
+              user_has_auth: true
+            type: user_addons
+            id: dropbox

--- a/swagger-spec/users/addons_list.yaml
+++ b/swagger-spec/users/addons_list.yaml
@@ -1,9 +1,16 @@
 # /users/{user_id}/addons/
 get:
-  summary: List all addons
+  summary: List all user addons
   description: >-
 
-    A paginated list of addons authoried by this user
+    A paginated list of authorized user addons
+
+
+    #### Permissions
+
+
+    User addons are visible only to the user that has ownership of them.
+
 
     #### Returns
 
@@ -28,128 +35,32 @@ get:
   tags:
     - Users
   operationId: users_addons_list
-  x-response-schema: Addon
+  x-response-schema: User Addon
   responses:
     '200':
       description: OK
       schema:
         type: array
         items:
-          $ref: '../addons/definition.yaml'
+          $ref: 'user_addon_definition.yaml'
       examples:
         application/json:
           data:
-          - links: {}
+          - links:
+              self: https://api.osf.io/v2/users/me/addons/dropbox/
+              accounts:
+                58d16ece9ad5a10201025eb4:
+                  nodes_connected: []
+                  account: https://api.osf.io/v2/users/f542f/addons/dropbox/accounts/58d16ece9ad5a10201025eb4/
             attributes:
-              url: http://www.box.com
-              name: Box
-              categories:
-              - storage
-              description: Box is a file storage add-on. Connect your Box account to an OSF
-                project to interact with files hosted on Box via the OSF.
-            type: addon
-            id: box
-          - links: {}
-            attributes:
-              url: https://dataverse.harvard.edu/
-              name: Dataverse
-              categories:
-              - storage
-              description: Dataverse is an open source software application to share, cite,
-                and archive data. Connect your Dataverse account to share your Dataverse datasets
-                via the OSF.
-            type: addon
-            id: dataverse
-          - links: {}
-            attributes:
-              url: http://www.dropbox.com
-              name: Dropbox
-              categories:
-              - storage
-              description: Dropbox is a file storage add-on. Connect your Dropbox account to
-                an OSF project to interact with files hosted on Dropbox via the OSF.
-            type: addon
+              user_has_auth: true
+            type: user_addons
             id: dropbox
-          - links: {}
-            attributes:
-              url: http://www.figshare.com
-              name: figshare
-              categories:
-              - storage
-              description: Figshare is an online digital repository. Connect your figshare account
-                to share your figshare files along with other materials in your OSF project.
-            type: addon
-            id: figshare
-          - links: {}
-            attributes:
-              url: http://www.github.com
-              name: GitHub
-              categories:
-              - storage
-              description: GitHub is a web-based Git repository hosting service. Connect your
-                GitHub repo to your OSF project to share your code alongside other materials
-                in your OSF project.
-            type: addon
-            id: github
-          - links: {}
-            attributes:
-              url: http://www.mendeley.com
-              name: Mendeley
-              categories:
-              - citations
-              description: Mendeley is a reference management tool. Connecting Mendeley folders
-                to OSF projects allows you and others to view, copy, and download citations
-                that are relevant to your project from the Project Overview page.
-            type: addon
-            id: mendeley
-          - links: {}
-            attributes:
-              url: http://www.zotero.org
-              name: Zotero
-              categories:
-              - citations
-              description: Zotero is a reference management tool. Connecting Zotero folders
-                to OSF projects allows you and others to view, copy, and download citations
-                that are relevant to your project from the Project Overview page.
-            type: addon
-            id: zotero
-          - links: {}
-            attributes:
-              url: https://owncloud.org/
-              name: ownCloud
-              categories:
-              - storage
-              description: ownCloud is an open source, self-hosted file sync and share app platform.
-                Connect your ownCloud account to an OSF project to interact with files hosted
-                on ownCloud via the OSF.
-            type: addon
-            id: owncloud
-          - links: {}
-            attributes:
-              url: https://aws.amazon.com/s3/
-              name: Amazon S3
-              categories:
-              - storage
-              description: Amazon S3 is a file storage add-on. Connect your S3 account to an
-                OSF project to interact with files hosted on S3 via the OSF.
-            type: addon
-            id: s3
-          - links: {}
-            attributes:
-              url: https://drive.google.com
-              name: Google Drive
-              categories:
-              - storage
-              description: Google Drive is a file storage add-on. Connect your Google Drive
-                account to an OSF project to interact with files hosted on Google Drive via
-                the OSF.
-            type: addon
-            id: googledrive
           links:
             first:
             last:
             prev:
             next:
             meta:
-            total: 10
-            per_page: 1000
+              total: 1
+              per_page: 10

--- a/swagger-spec/users/addons_list.yaml
+++ b/swagger-spec/users/addons_list.yaml
@@ -9,7 +9,7 @@ get:
     #### Permissions
 
 
-    User addons are visible only to the user that has ownership of them.
+    User addons are visible only to the user that authorized the addon.
 
 
     #### Returns
@@ -23,6 +23,14 @@ get:
 
     The `links` key contains a dictionary of links that can be used
     for [pagination](#Introduction_pagination).
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+    to understand why this request may have failed.
+
+
+    Attempting to request the accounts for an addon that is not enabled will result in a **404 Not Found** response.
 
   parameters:
     - in: path
@@ -47,20 +55,57 @@ get:
         application/json:
           data:
           - links:
+              self: https://api.osf.io/v2/users/me/addons/box/
+              accounts:
+                562d9acf8c5e4a14112e489e:
+                  nodes_connected:
+                  - https://api.osf.io/v2/nodes/t3y58/
+                  account: https://api.osf.io/v2/users/q7fts/addons/box/accounts/562d9acf8c5e4a14112e489e/
+            attributes:
+              user_has_auth: true
+            type: user_addons
+            id: box
+          - links:
               self: https://api.osf.io/v2/users/me/addons/dropbox/
               accounts:
-                58d16ece9ad5a10201025eb4:
+                56742db88c5e4a396d689e3e:
                   nodes_connected: []
-                  account: https://api.osf.io/v2/users/f542f/addons/dropbox/accounts/58d16ece9ad5a10201025eb4/
+                  account: https://api.osf.io/v2/users/q7fts/addons/dropbox/accounts/56742db88c5e4a396d689e3e/
             attributes:
               user_has_auth: true
             type: user_addons
             id: dropbox
+          - links:
+              self: https://api.osf.io/v2/users/me/addons/github/
+              accounts:
+                570edf7f9ad5a101f90030f6:
+                  nodes_connected:
+                  - https://api.osf.io/v2/nodes/t3y58/
+                  account: https://api.osf.io/v2/users/q7fts/addons/github/accounts/570edf7f9ad5a101f90030f6/
+            attributes:
+              user_has_auth: true
+            type: user_addons
+            id: github
+          - links:
+              self: https://api.osf.io/v2/users/me/addons/googledrive/
+              accounts:
+                58fe1cb59ad5a1025c8ae281:
+                  nodes_connected: []
+                  account: https://api.osf.io/v2/users/q7fts/addons/googledrive/accounts/58fe1cb59ad5a1025c8ae281/
+                563c1c518c5e4a36e7dc5450:
+                  nodes_connected:
+                  - https://api.osf.io/v2/nodes/6y5jf/
+                  - https://api.osf.io/v2/nodes/t3y58/
+                  account: https://api.osf.io/v2/users/q7fts/addons/googledrive/accounts/563c1c518c5e4a36e7dc5450/
+            attributes:
+              user_has_auth: true
+            type: user_addons
+            id: googledrive
           links:
             first:
             last:
             prev:
-            next:
+            next: 
             meta:
-              total: 1
+              total: 4
               per_page: 10

--- a/swagger-spec/users/addons_list.yaml
+++ b/swagger-spec/users/addons_list.yaml
@@ -1,1 +1,155 @@
 # /users/{user_id}/addons/
+get:
+  summary: List all addons
+  description: >-
+
+    A paginated list of addons authoried by this user
+
+    #### Returns
+
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains an array of up to 10 addons.
+    Each resource in the array is a separate addon object.
+
+
+    The `links` key contains a dictionary of links that can be used
+    for [pagination](#Introduction_pagination).
+
+  parameters:
+    - in: path
+      type: string
+      name: user_id
+      required: true
+      description: 'The unique identifier of the user.'
+
+
+  tags:
+    - Users
+  operationId: users_addons_list
+  x-response-schema: Addon
+  responses:
+    '200':
+      description: OK
+      schema:
+        type: array
+        items:
+          $ref: '../addons/definition.yaml'
+      examples:
+        application/json:
+          data:
+          - links: {}
+            attributes:
+              url: http://www.box.com
+              name: Box
+              categories:
+              - storage
+              description: Box is a file storage add-on. Connect your Box account to an OSF
+                project to interact with files hosted on Box via the OSF.
+            type: addon
+            id: box
+          - links: {}
+            attributes:
+              url: https://dataverse.harvard.edu/
+              name: Dataverse
+              categories:
+              - storage
+              description: Dataverse is an open source software application to share, cite,
+                and archive data. Connect your Dataverse account to share your Dataverse datasets
+                via the OSF.
+            type: addon
+            id: dataverse
+          - links: {}
+            attributes:
+              url: http://www.dropbox.com
+              name: Dropbox
+              categories:
+              - storage
+              description: Dropbox is a file storage add-on. Connect your Dropbox account to
+                an OSF project to interact with files hosted on Dropbox via the OSF.
+            type: addon
+            id: dropbox
+          - links: {}
+            attributes:
+              url: http://www.figshare.com
+              name: figshare
+              categories:
+              - storage
+              description: Figshare is an online digital repository. Connect your figshare account
+                to share your figshare files along with other materials in your OSF project.
+            type: addon
+            id: figshare
+          - links: {}
+            attributes:
+              url: http://www.github.com
+              name: GitHub
+              categories:
+              - storage
+              description: GitHub is a web-based Git repository hosting service. Connect your
+                GitHub repo to your OSF project to share your code alongside other materials
+                in your OSF project.
+            type: addon
+            id: github
+          - links: {}
+            attributes:
+              url: http://www.mendeley.com
+              name: Mendeley
+              categories:
+              - citations
+              description: Mendeley is a reference management tool. Connecting Mendeley folders
+                to OSF projects allows you and others to view, copy, and download citations
+                that are relevant to your project from the Project Overview page.
+            type: addon
+            id: mendeley
+          - links: {}
+            attributes:
+              url: http://www.zotero.org
+              name: Zotero
+              categories:
+              - citations
+              description: Zotero is a reference management tool. Connecting Zotero folders
+                to OSF projects allows you and others to view, copy, and download citations
+                that are relevant to your project from the Project Overview page.
+            type: addon
+            id: zotero
+          - links: {}
+            attributes:
+              url: https://owncloud.org/
+              name: ownCloud
+              categories:
+              - storage
+              description: ownCloud is an open source, self-hosted file sync and share app platform.
+                Connect your ownCloud account to an OSF project to interact with files hosted
+                on ownCloud via the OSF.
+            type: addon
+            id: owncloud
+          - links: {}
+            attributes:
+              url: https://aws.amazon.com/s3/
+              name: Amazon S3
+              categories:
+              - storage
+              description: Amazon S3 is a file storage add-on. Connect your S3 account to an
+                OSF project to interact with files hosted on S3 via the OSF.
+            type: addon
+            id: s3
+          - links: {}
+            attributes:
+              url: https://drive.google.com
+              name: Google Drive
+              categories:
+              - storage
+              description: Google Drive is a file storage add-on. Connect your Google Drive
+                account to an OSF project to interact with files hosted on Google Drive via
+                the OSF.
+            type: addon
+            id: googledrive
+          links:
+            first:
+            last:
+            prev:
+            next:
+            meta:
+            total: 10
+            per_page: 1000

--- a/swagger-spec/users/user_addon_definition.yaml
+++ b/swagger-spec/users/user_addon_definition.yaml
@@ -1,0 +1,47 @@
+type: object
+title: User Addon
+required:
+  - id
+  - type
+  - attributes
+  - links
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The unique identifier of the user addon entity.'
+
+  type:
+    type: string
+    readOnly: true
+    description: 'The type identifier of the user addon entity (`user_addons`).'
+
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: true
+    description: 'The properties of the user addon entity.'
+    required:
+      - user_has_auth
+    properties:
+      user_has_auth:
+        type: boolean
+        readOnly: true
+        description: 'Whether or not the user has access to this user addon.'
+
+  links:
+    type: object
+    title: Links
+    readOnly: true
+    description: 'URLs to alternative representations of the user addon entity.'
+    properties:
+      self:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'The canonical API endpoint to this user addon.'
+      accounts:
+        type: object
+        format: URL
+        readOnly: true
+        description: 'A dictionary with addon_account id as key, an array of connected nodes and link to user account as value'


### PR DESCRIPTION
#### Purpose
Add documentation for user addons endpoints

#### Changes
- Add model definition for user external (addon) accounts
- Add documentation for users addons list, addon detail, external account list, external account detail.

#### Ticket
- [OSF-7469](https://openscience.atlassian.net/browse/OSF-7469)
