### PR TITLE
Documentation for QuickfFiles 

### DIFF
--- a/swagger-spec/files/definition.yaml
+++ b/swagger-spec/files/definition.yaml
@@ -95,6 +95,11 @@ properties:
         format: URL
         readOnly: true
         description: A link to the node the file is on.
+      user:
+        type: string
+        format: URL
+        readOnly: true
+        description: A link to the user the file belongs to. Used when the file is on a QuickFiles Node.
       checkout:
         type: string
         format: URL

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -419,6 +419,9 @@ paths:
   /users/{user_id}/preprints/:
     $ref: 'users/preprints_list.yaml'
 
+  /users/{user_id}/quickfiles/:
+    $ref: 'users/quickfiles_list.yaml'
+
   /users/{user_id}/registrations/:
     $ref: 'users/registrations_list.yaml'
 

--- a/swagger-spec/users/definition.yaml
+++ b/swagger-spec/users/definition.yaml
@@ -79,6 +79,10 @@ properties:
         type: string
         readOnly: true
         description: 'A link to the list of nodes the user is a contributor to.'
+      quickfiles:
+        type: string
+        readOnly: true
+        description: "Links related to a user's quickfiles. Includes upload, download, and list of files on the quickfiles node."
 
   links:
     type: object

--- a/swagger-spec/users/detail.yaml
+++ b/swagger-spec/users/detail.yaml
@@ -55,6 +55,17 @@ get:
                   related:
                     href: https://api.osf.io/v2/users/q7fts/institutions/
                     meta: {}
+              quickfiles:
+                links:
+                  download:
+                    href: http://localhost:7777/v1/resources/rwc4ua7tez/providers/osfstorage/?zip=
+                    meta: {}
+                  upload:
+                    href: http://localhost:7777/v1/resources/rwc4ua7tez/providers/osfstorage/
+                    meta: {}
+                  related:
+                    href: https://api.osf.io/v2/users/q7fts/quickfiles/
+                    meta: {}
             links:
               self: https://api.osf.io/v2/users/q7fts/
               html: https://osf.io/q7fts/

--- a/swagger-spec/users/list.yaml
+++ b/swagger-spec/users/list.yaml
@@ -63,6 +63,17 @@ get:
                   related:
                     href: https://api.osf.io/v2/users/q7fts/institutions/
                     meta: {}
+              quickfiles:
+                links:
+                  download:
+                    href: http://localhost:7777/v1/resources/rwc4ua7tez/providers/osfstorage/?zip=
+                    meta: {}
+                  upload:
+                    href: http://localhost:7777/v1/resources/rwc4ua7tez/providers/osfstorage/
+                    meta: {}
+                  related:
+                    href: https://api.osf.io/v2/users/q7fts/quickfiles/
+                    meta: {}
             links:
               self: https://api.osf.io/v2/users/q7fts/
               html: https://osf.io/q7fts/

--- a/swagger-spec/users/quickfiles_list.yaml
+++ b/swagger-spec/users/quickfiles_list.yaml
@@ -1,0 +1,78 @@
+get:
+  summary: "List a user's quickfiles"
+  description: >-
+    A paginated list of files that are stored on the user's Quickfiles Node
+
+    #### Returns
+
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains an array of 10 files.
+    Each resource in the array is a complete file object and contains the full representation of the file.
+
+
+    The `links` key contains a dictionary of links that can be used
+    for [pagination](#Introduction_pagination).
+
+  tags:
+    - Users
+  parameters:
+    - in: path
+      type: string
+      name: user_id
+      required: true
+      description: 'The unique identifier of the user.'
+  operationId: users_quickfiles_list
+  x-response-schema: File
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        type: array
+        items:
+          $ref: '../files/definition.yaml'
+      examples:
+        application/json:
+          data:
+            - relationships:
+                user:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/jk5cv/
+                      meta: {}
+                versions:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/files/553e69248c5e4a219919ea54/versions/
+                      meta: {}
+              links:
+                info: https://api.osf.io/v2/files/553e69248c5e4a219919ea54/
+                self: https://api.osf.io/v2/files/553e69248c5e4a219919ea54/
+                move: https://files.osf.io/v1/resources/ezcuj/providers/osfstorage/553e69248c5e4a219919ea54
+                upload: https://files.osf.io/v1/resources/ezcuj/providers/osfstorage/553e69248c5e4a219919ea54
+                download: https://files.osf.io/v1/resources/ezcuj/providers/osfstorage/553e69248c5e4a219919ea54
+                delete: https://files.osf.io/v1/resources/ezcuj/providers/osfstorage/553e69248c5e4a219919ea54
+              attributes:
+                extra:
+                  hashes:
+                    sha256: 2450eb9ff3db92a1bff370368b0552b270bd4b5ca0745b773c37d2662f94df8e
+                    md5: 44325d4f13b09f3769ede09d7c20a82c
+                  downloads: 442
+                kind: file
+                name: OSC2012.pdf
+                last_touched: '2015-09-18T01:11:16.328000'
+                materialized_path: "/OSC2012.pdf"
+                date_modified: '2014-10-17T19:24:12.264Z'
+                current_version: 1
+                delete_allowed: true
+                date_created: '2014-10-17T19:24:12.264Z'
+                provider: osfstorage
+                path: "/553e69248c5e4a219919ea54"
+                current_user_can_comment: true
+                guid: sejcv
+                checkout:
+                tags: []
+                size: 216945
+              type: files
+              id: 553e69248c5e4a219919ea54


### PR DESCRIPTION

![screen shot 2017-08-22 at 3 21 16 pm](https://user-images.githubusercontent.com/801594/29583278-94fadb40-874d-11e7-9100-e5fe66b6ffd2.png)


#### Purpose
Soon, users will have `/v2/users/<user_id>/quickfiles/` which will show all of the files uploaded to a special quickfiles node. Add this to the documentation!

#### Changes
- Add `List a user's quickfiles` to user section
    * along with appropriate examples
- Add optional `user` relationship to files definition
- Add quickfiles relationship to user definition
- Add quickfiles relationship examples to user detail and list

#### Ticket
https://openscience.atlassian.net/browse/OSF-8117
